### PR TITLE
Improve particle treatment for SMASH initial conditions

### DIFF
--- a/src/icPartSMASH.cpp
+++ b/src/icPartSMASH.cpp
@@ -4,6 +4,7 @@
 #include <sstream>
 #include <iomanip>
 #include <cfloat>
+#include <vector>
 
 #include "eos.h"
 #include "eoChiral.h"
@@ -84,8 +85,22 @@ IcPartSMASH::IcPartSMASH(Fluid* f, char* filename, double _Rgt, double _Rgz,
   instream.str(line);
   instream.seekg(0);
   instream.clear();
-  instream >> Tau[np] >> X[np] >> Y[np] >> Eta[np] >> Mt[np] >> Px[np] >>
-      Py[np] >> Rap[np] >> Id[np] >> Charge[np];
+  // Read line
+  instream >> Tau_val >> X_val >> Y_val >> Eta_val >> Mt_val >> Px_val >>
+              Py_val >> Rap_val >> Id_val >> Charge_val;
+
+  // Fill arrays
+  Tau.push_back(Tau_val);
+  X.push_back(X_val);
+  Y.push_back(Y_val);
+  Eta.push_back(Eta_val);
+  Mt.push_back(Mt_val);
+  Px.push_back(Px_val);
+  Py.push_back(Py_val);
+  Rap.push_back(Rap_val);
+  Id.push_back(Id_val);
+  Charge.push_back(Charge_val);
+
 #ifdef TSHIFT
   Eta[np] = TMath::ATanH(Tau[np] * sinh(Eta[np]) /
                          (Tau[np] * cosh(Eta[np]) + tshift));
@@ -105,7 +120,6 @@ IcPartSMASH::IcPartSMASH(Fluid* f, char* filename, double _Rgt, double _Rgz,
    nevents++;
    // if(nevents>10000) return ;
   }
-  if (np > NP - 1) cout << "ERROR: increase NP constant\n";
  }
  if (nevents > 1)
   cout << "++ Warning: loaded " << nevents << "  initial SMASH events\n";

--- a/src/icPartSMASH.cpp
+++ b/src/icPartSMASH.cpp
@@ -117,6 +117,19 @@ IcPartSMASH::IcPartSMASH(Fluid* f, char* filename, double _Rgt, double _Rgz,
    }
    makeSmoothTable(np);
    np = 0;
+
+   // Clear arrays for next event
+   Tau.clear();
+   X.clear();
+   Y.clear();
+   Eta.clear();
+   Mt.clear();
+   Px.clear();
+   Py.clear();
+   Rap.clear();
+   Id.clear();
+   Charge.clear();
+
    nevents++;
    // if(nevents>10000) return ;
   }

--- a/src/icPartSMASH.h
+++ b/src/icPartSMASH.h
@@ -8,10 +8,12 @@ private:
  double xmin, xmax, ymin, ymax, zmin, zmax;
  double dx, dy, dz;
  double ***T00, ***T0x, ***T0y, ***T0z, ***QB, ***QE;
- static const int NP = 10000;  // dimension for particle arrays
- // auxiliary particle arrays
- double Tau[NP], X[NP], Y[NP], Eta[NP], Mt[NP], Px[NP], Py[NP], Rap[NP];
- int Id[NP], Charge[NP];
+ // auxiliary particle values for reading from file
+ double Tau_val, X_val, Y_val, Eta_val, Mt_val, Px_val, Py_val, Rap_val;
+ int Id_val, Charge_val;
+  // auxiliary particle arrays
+ std::vector<double> Tau, X, Y, Eta, Mt, Px, Py, Rap;
+ std::vector<int> Id, Charge;
 
  double tau0;
  double Rgx, Rgy, Rgz;


### PR DESCRIPTION
* Ged rid of the NP constant marking the hard-coded size of the
  auxiliary arrays containing the particle properties
* Replace arrays by use of std::vector
* Allow for any number of particles in the initial state to be read in,
  not limited to predefined NP

Fixes #7