### PR TITLE
proper treatment of small/zero tau_pi, tau_Pi cases

### DIFF
--- a/src/trancoeff.cpp
+++ b/src/trancoeff.cpp
@@ -32,12 +32,10 @@ void TransportCoeff::getEta(double e, double T, double &_etaS, double &_zetaS) {
 }
 
 void TransportCoeff::getTau(double e, double T, double &_taupi, double &_tauPi) {
- if (T > 0.)
-  _taupi = std::max(5. / 5.068 * etaS / T, 0.003);
- else
-  _taupi = 0.1;
- if (T > 0.)
-  _tauPi = std::max(1. / 5.068 * zetaS(e,T) / (15. * pow(0.33333-eos->cs2(e),2) * T), 0.005);
- else
-  _tauPi = 0.1;
+ if (T > 0.) {
+  _taupi = 5. / 5.068 * etaS / T;
+  _tauPi = 1. / 5.068 * zetaS(e,T) / (15. * pow(0.33333-eos->cs2(e),2) * T);
+ } else {
+  _taupi = _tauPi = 0.;
+ }
 }


### PR DESCRIPTION
When the tau_pi or tau_Pi are small or zero, as the relaxation term
in the Israel-Stewart equations has to be treated differently.
That is particularly important since with the ansatze used, the
relaxation times are proportional to eta/s and zeta/s, therefore e.g.
zeta/s=0 case results in tau_Pi=0.

This commit applies a simplified treatment of such cases: when tau_pi or
tau_Pi become smaller than 1/2 of timestep, the coefficients in front of
the higher-order terms in the respective shear or bulk evolution
equations are set to zero, and the contributions from the relaxation terms
are not computed, instead respectively pi=piNS or Pi=PiNS values are
set. Therefore, locally when tau_pi or tau_Pi are small, the
evoultionary equations are reduced to the Navier-Stokes limit.