### PR TITLE
Add missing include in icPartSMASH.h

### DIFF
--- a/src/icPartSMASH.h
+++ b/src/icPartSMASH.h
@@ -1,3 +1,4 @@
+#include <vector>
 
 class Fluid;
 class EoS;


### PR DESCRIPTION
This missing include statement resulted in compilation failures on some architectures.