### PR TITLE
Modifications to be compatible with SMASH hadronic EoS in the final stage

### DIFF
--- a/src/fld.cpp
+++ b/src/fld.cpp
@@ -768,34 +768,36 @@ void Fluid::outputCorona(double tau) {
        cc->getPrimVar(eos, tau, e, _p, _nb, _nq, _ns, _vx, _vy, _vz);
        cc->getQ(QCube[jx][jy][jz]);
        if (e > ecrit) isCorona = false;
-       if (e > 0.0001) isTail = false;
        // ---- get viscous tensor
        for (int ii = 0; ii < 4; ii++)
         for (int jj = 0; jj <= ii; jj++)
          piSquare[jx][jy][jz][index44(ii, jj)] = cc->getpi(ii, jj);
        PiSquare[jx][jy][jz] = cc->getPi();
       }
+
+    // ---- interpolation procedure
+    double vxC = 0., vyC = 0., vzC = 0., TC = 0., mubC = 0., muqC = 0.,
+           musC = 0., piC[10], PiC = 0., nbC = 0.,
+           nqC = 0.;  // values at the centre, to be interpolated
+    double QC[7] = {0., 0., 0., 0., 0., 0., 0.};
+    double eC = 0., pC = 0.;
+    for (int ii = 0; ii < 10; ii++) piC[ii] = 0.0;
+    for (int jx = 0; jx < 2; jx++)
+     for (int jy = 0; jy < 2; jy++)
+      for (int jz = 0; jz < 2; jz++)
+       for (int i = 0; i < 7; i++) {
+        QC[i] += QCube[jx][jy][jz][i] * 0.125;
+       }
+    for (int i = 0; i < 7; i++) QC[i] = QC[i] / tau;
+    double _ns = 0.0;
+    transformPV(eos, QC, eC, pC, nbC, nqC, _ns, vxC, vyC, vzC);
+    if (eC >= 0.01) isTail = false;
+
     if (isCorona && !isTail) {
-     nelements++;
-     output::ffreeze.precision(15);
-     output::ffreeze << setw(24) << tau << setw(24) << getX(ix) + 0.5 * dx << setw(24)
-             << getY(iy) + 0.5 * dy << setw(24) << getZ(iz) + 0.5 * dz;
-     // ---- interpolation procedure
-     double vxC = 0., vyC = 0., vzC = 0., TC = 0., mubC = 0., muqC = 0.,
-            musC = 0., piC[10], PiC = 0., nbC = 0.,
-            nqC = 0.;  // values at the centre, to be interpolated
-     double QC[7] = {0., 0., 0., 0., 0., 0., 0.};
-     double eC = 0., pC = 0.;
-     for (int ii = 0; ii < 10; ii++) piC[ii] = 0.0;
-     for (int jx = 0; jx < 2; jx++)
-      for (int jy = 0; jy < 2; jy++)
-       for (int jz = 0; jz < 2; jz++)
-        for (int i = 0; i < 7; i++) {
-         QC[i] += QCube[jx][jy][jz][i] * 0.125;
-        }
-     for (int i = 0; i < 7; i++) QC[i] = QC[i] / tau;
-     double _ns = 0.0;
-     transformPV(eos, QC, eC, pC, nbC, nqC, _ns, vxC, vyC, vzC);
+      nelements++;
+      output::ffreeze.precision(15);
+      output::ffreeze << setw(24) << tau << setw(24) << getX(ix) + 0.5 * dx << setw(24)
+              << getY(iy) + 0.5 * dy << setw(24) << getZ(iz) + 0.5 * dz;
      eos->eos(eC, nbC, nqC, _ns, TC, mubC, muqC, musC, pC);
      if (TC > 0.4 || fabs(mubC) > 0.99) {
       cout << "#### Error (surface): high T/mu_b ####\n";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -243,7 +243,7 @@ int main(int argc, char **argv) {
  if (eosTypeHadron == 0) {
    eosH = new EoSHadron((char*)"eos/eosHadronLog.dat"); //PDG hadronic EoS
  } else if (eosTypeHadron == 1) {
-   eosH = new EoSSmash((char*)"eos/hadgas_eos_SMASH.dat", 101, 101, 101); //SMASH hadronic EoS
+   eosH = new EoSSmash((char*)"eos/hadgas_eos_SMASH.dat", 101, 51, 51); //SMASH hadronic EoS
  } else {
    cout << "Unknown haronic EoS type for hypersurface creation.\n" <<
            "eosTypeHadron should be either \"0\" (PDG hadronic EoS) or " <<


### PR DESCRIPTION
- Update grid of SMASH EoS
- Modify determination of whether corona cell is in Tail. Previously, a
cell was considered in the Tail if the energy density in any of the
corners was above a certain value. This is now modified to consider the
energy density in the center of the cell, obtained from interpolation of T^{0mu} and not from e. This value is also used to create the freezeout surface.