### PR TITLE
Allow parameterization of shear viscosity

### DIFF
--- a/src/hdo.cpp
+++ b/src/hdo.cpp
@@ -418,7 +418,7 @@ void Hydro::NSquant(int ix, int iy, int iz, double pi[4][4], double &Pi,
  double etaS, zetaS;
  double s = eos->s(e1, nb, nq, ns);  // entropy density in the current cell
  eos->eos(e1, nb, nq, ns, T, mub, muq, mus, p);
- trcoeff->getEta(e1, T, etaS, zetaS);
+ trcoeff->getEta(e1, nb, T, etaS, zetaS);
  //##############
  // if(e1<0.00004) s=0. ; // negative pressure due to pi^zz for small e
  ut0 = 1.0 / sqrt(1.0 - vx0 * vx0 - vy0 * vy0 - vz0 * vz0);
@@ -597,7 +597,7 @@ void Hydro::setNSvalues() {
     double etaS, zetaS;
     double s = eos->s(e, nb, nq, ns);  // entropy density in the current cell
     eos->eos(e, nb, nq, ns, T, mub, muq, mus, p);
-    trcoeff->getEta(e, T, etaS, zetaS);
+    trcoeff->getEta(e,nb, T, etaS, zetaS);
     for (int i = 0; i < 4; i++)
      for (int j = 0; j < 4; j++) piNS[i][j] = 0.0;  // reset piNS
     piNS[1][1] = piNS[2][2] = 2.0 / 3.0 * etaS * s / tau / 5.068;
@@ -648,7 +648,7 @@ void Hydro::ISformal() {
      NSquant(ix, iy, iz, piNS, PiNS, dmu, du);
      eos->eos(e, nb, nq, ns, T, mub, muq, mus, p);
      double etaS, zetaS;
-     trcoeff->getEta(e, T, etaS, zetaS);
+     trcoeff->getEta(e,nb, T, etaS, zetaS);
      const double s = eos->s(e, nb, nq, ns);
      const double eta = etaS * s;
      // auxiliary variable sigmaNS = piNS / (2*eta), 
@@ -660,7 +660,7 @@ void Hydro::ISformal() {
      }
      //############# get relaxation times
      double taupi, tauPi;
-     trcoeff->getTau(e, T, taupi, tauPi);
+     trcoeff->getTau(e, nb, T, taupi, tauPi);
      double deltapipi, taupipi, lambdapiPi, phi7, delPiPi, lamPipi;
      trcoeff->getOther(e, nb, nq, ns, deltapipi, taupipi, lambdapiPi, phi7);
      phi7 = phi7/taupi;  // dividing by tau_pi here, to avoid NaNs when tau_pi==0

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,11 +43,11 @@
 using namespace std;
 
 // program parameters, to be read from file
-int nx, ny, nz, eosType;
+int nx, ny, nz, eosType, etaSparam = 0;
 int eosTypeHadron = 0;
 double xmin, xmax, ymin, ymax, etamin, etamax, tau0, tauMax, tauResize, dtau;
 string collSystem, outputDir, isInputFile;
-double etaS, zetaS, eCrit;
+double etaS, zetaS, eCrit, eEtaSMin, al, ah, aRho, T0, etaSMin;
 int icModel,
     glauberVariable =
         1;  // icModel=1 for pure Glauber, 2 for table input (Glissando etc)
@@ -120,6 +120,20 @@ void readParameters(char *parFile) {
    impactPar = atof(parValue);
   else if (strcmp(parName, "s0ScaleFactor") == 0)
    s0ScaleFactor = atof(parValue);
+  else if (strcmp(parName, "etaSparam") == 0)
+   etaSparam = atoi(parValue);
+  else if (strcmp(parName, "aRho") == 0)
+   aRho = atof(parValue);
+  else if (strcmp(parName, "ah") == 0)
+   ah = atof(parValue);
+  else if (strcmp(parName, "al") == 0)
+   al = atof(parValue);
+  else if (strcmp(parName, "T0") == 0)
+   T0 = atof(parValue);
+  else if (strcmp(parName, "eEtaSMin") == 0)
+   eEtaSMin = atof(parValue);
+  else if (strcmp(parName, "etaSMin") == 0)
+   etaSMin = atof(parValue);
   else if (parName[0] == '!')
    cout << "CCC " << sline.str() << endl;
   else
@@ -149,7 +163,23 @@ void printParameters() {
  cout << "tauGridResize = " << tauResize << endl;
  cout << "dtau = " << dtau << endl;
  cout << "e_crit = " << eCrit << endl;
- cout << "eta/s = " << etaS << endl;
+ cout << "etaSparam = " << etaSparam << endl;
+ if (etaSparam == 0){
+    cout << "eta/s = " << etaS << endl;
+ }
+ else if (etaSparam == 1){
+    cout << "al = " << al << endl;
+    cout << "ah = " << ah << endl;
+    cout << "etaSMin = " << etaSMin << endl;
+    cout << "T0 = " << T0 << endl;
+ }
+ else if (etaSparam == 2){
+    cout << "al = " << al << endl;
+    cout << "ah = " << ah << endl;
+    cout << "aRho = " << aRho << endl;
+    cout << "etaSMin = " << etaSMin << endl;
+    cout << "eEtaSMin = " << eEtaSMin << endl;
+ }
  cout << "zeta/s = " << zetaS << endl;
  cout << "epsilon0 = " << epsilon0 << endl;
  cout << "Rgt = " << Rgt << "  Rgz = " << Rgz << endl;
@@ -253,7 +283,7 @@ int main(int argc, char **argv) {
 
 
  // transport coefficients
- trcoeff = new TransportCoeff(etaS, zetaS, eos);
+ trcoeff = new TransportCoeff(etaS, zetaS, eos, etaSparam, ah, al, aRho, T0, etaSMin, eEtaSMin);
 
  f = new Fluid(eos, eosH, trcoeff, nx, ny, nz, xmin, xmax, ymin, ymax, etamin,
                etamax, dtau, eCrit);

--- a/src/trancoeff.cpp
+++ b/src/trancoeff.cpp
@@ -4,10 +4,17 @@
 #include "trancoeff.h"
 #include "inc.h"
 
-TransportCoeff::TransportCoeff(double _etaS, double _zetaS, EoS *_eos) {
- etaS = _etaS;
+TransportCoeff::TransportCoeff(double _etaS, double _zetaS, EoS *_eos, int _etaSparam, double _ah, double _al, double _aRho, double _T0, double _etaSMin, double _eEtaSMin) {
+ etaS0 = _etaS;
  zetaS0 = _zetaS;
  eos = _eos;
+ etaSparam = _etaSparam;
+ ah = _ah;
+ al = _al;
+ aRho =_aRho;
+ etaSMin = _etaSMin;
+ eEtaSMin = _eEtaSMin;
+ T0=_T0;
 }
 
 void TransportCoeff::printZetaT()
@@ -26,14 +33,27 @@ double TransportCoeff::zetaS(double e, double T)
  return zetaS0 * (1. / 3. - eos->cs2(e)) / (exp((0.16 - T) / 0.001) + 1.);
 }
 
-void TransportCoeff::getEta(double e, double T, double &_etaS, double &_zetaS) {
- _etaS = etaS;
+void TransportCoeff::getEta(double e, double rho, double T, double &_etaS, double &_zetaS) {
+ _etaS = etaS(e,rho, T);
  _zetaS = zetaS(e,T);
 }
 
-void TransportCoeff::getTau(double e, double T, double &_taupi, double &_tauPi) {
+double TransportCoeff::etaS(double e,double rho, double T)
+{
+  if (etaSparam == 0){
+      return etaS0;
+  }
+  else if (etaSparam == 1){
+      return etaSMin +  ((T>T0) ? ah*(T-T0) :  al*(T-T0));
+  }
+  else if (etaSparam == 2){
+      return std::max(0.0, etaSMin + ((e>eEtaSMin) ? ( (ah*(e-eEtaSMin)+aRho*rho) ): al*(e-eEtaSMin)+aRho*rho));
+  }
+}
+
+void TransportCoeff::getTau(double e, double rho, double T, double &_taupi, double &_tauPi) {
  if (T > 0.) {
-  _taupi = 5. / 5.068 * etaS / T;
+  _taupi = 5. / 5.068 * etaS(e,rho, T) / T;
   _tauPi = 1. / 5.068 * zetaS(e,T) / (15. * pow(0.33333-eos->cs2(e),2) * T);
  } else {
   _taupi = _tauPi = 0.;

--- a/src/trancoeff.h
+++ b/src/trancoeff.h
@@ -4,18 +4,19 @@ class EoS;
 // of the fluid: eta/s, zeta/s and the corresponding relaxation times,
 // taupi (\tau_\pi) and tauPi (\tau_\Pi)
 class TransportCoeff {
- double etaS, zetaS0, taupi, tauPi;
- EoS *eos;  // EoS instance is needed optionally for zeta/s parametrization,
+ double etaS0, zetaS0, taupi, tauPi, etaSparam, ah, al, aRho, etaSMin, eEtaSMin, T0;
+ EoS *eos;  // EoS instance is needed optionally for zeta/s or eta/s parametrization,
             // which depends on the speed of sound
  double zetaS(double e, double T);
+ double etaS(double e,double rho, double T);
 public:
- TransportCoeff(double _etaS, double _zetaS, EoS *_eos);
+ TransportCoeff(double _etaS, double _zetaS, EoS *_eos, int _etaSparam, double _ah, double _al, double _aRho, double _T0, double _etaSMin, double _eEtaSMin);
  ~TransportCoeff(){};
  void printZetaT();
  // returns (optionally temperature dependent) eta/s and zeta/s
- void getEta(double e, double T, double &_etaS, double &_zetaS);
+ void getEta(double e, double rho, double T, double &_etaS, double &_zetaS);
  // returns shear and bulk relaxation times
- void getTau(double e, double T, double &_taupi, double &_tauPi);
+ void getTau(double e, double rho, double T, double &_taupi, double &_tauPi);
  // deltapipi, taupipi, lambdapiPi * divided by tau_pi * !
  void getOther(double e, double nb, double nq, double ns, 
    double &deltapipi, double &taupipi, double &lambdapiPi, double &phi7) {
@@ -29,7 +30,7 @@ public:
  }
  // isViscous tells whether the fluid is viscous or inviscid
  inline bool isViscous() {
-  if (etaS > 0. || zetaS0 > 0.)
+  if (etaS0 > 0. || zetaS0 > 0. || etaSparam>0)
    return true;
   else
    return false;


### PR DESCRIPTION
These changes allow choosing from one of three choices for eta/s: a constant value (`etaSparam=0`), a linear temperature-dependent shear viscosity (`etaSparam=1`), and shear viscosity parameterized in the energy density and net baryon-number density (`etaSparam=2`).