### PR TITLE
Add option to limit output

### DIFF
--- a/src/fld.cpp
+++ b/src/fld.cpp
@@ -111,46 +111,50 @@ Fluid::~Fluid() {
  delete cell0;
 }
 
-void Fluid::initOutput(const char *dir, double tau0) {
+void Fluid::initOutput(const char *dir, double tau0, bool hsOnly) {
+ // hsOnly (default false):
+ // if true only the hypersurface output is initialized
  char command[255];
  sprintf(command, "mkdir -p %s", dir);
  int return_mkdir = system(command);
  cout << "mkdir returns: " << return_mkdir << endl;
- string outx = dir;
- outx.append("/outx.dat");
- string outxvisc = dir;
- outxvisc.append("/outx.visc.dat");
- string outyvisc = dir;
- outyvisc.append("/outy.visc.dat");
- string outdiagvisc = dir;
- outdiagvisc.append("/diag.visc.dat");
- string outy = dir;
- outy.append("/outy.dat");
- string outdiag = dir;
- outdiag.append("/outdiag.dat");
- string outz = dir;
- outz.append("/outz.dat");
- string outaniz = dir;
- outaniz.append("/out.aniz.dat");
- string out2d = dir;
- out2d.append("/out2D.dat");
  string outfreeze = dir;
  outfreeze.append("/freezeout.dat");
- output::fx.open(outx.c_str());
- output::fy.open(outy.c_str());
- output::fz.open(outz.c_str());
- output::fdiag.open(outdiag.c_str());
- output::f2d.open(out2d.c_str());
- output::fxvisc.open(outxvisc.c_str());
- output::fyvisc.open(outyvisc.c_str());
- output::fdiagvisc.open(outdiagvisc.c_str());
- output::faniz.open(outaniz.c_str());
  output::ffreeze.open(outfreeze.c_str());
- //################################################################
- // important remark. for correct diagonal output, nx=ny must hold.
- //################################################################
- outputGnuplot(tau0);
- output::faniz << "#  tau  <<v_T>>  e_p  e'_p  (to compare with SongHeinz)\n";
+ if (!hsOnly) {
+  string outx = dir;
+  outx.append("/outx.dat");
+  string outxvisc = dir;
+  outxvisc.append("/outx.visc.dat");
+  string outyvisc = dir;
+  outyvisc.append("/outy.visc.dat");
+  string outdiagvisc = dir;
+  outdiagvisc.append("/diag.visc.dat");
+  string outy = dir;
+  outy.append("/outy.dat");
+  string outdiag = dir;
+  outdiag.append("/outdiag.dat");
+  string outz = dir;
+  outz.append("/outz.dat");
+  string outaniz = dir;
+  outaniz.append("/out.aniz.dat");
+  string out2d = dir;
+  out2d.append("/out2D.dat");
+  output::fx.open(outx.c_str());
+  output::fy.open(outy.c_str());
+  output::fz.open(outz.c_str());
+  output::fdiag.open(outdiag.c_str());
+  output::f2d.open(out2d.c_str());
+  output::fxvisc.open(outxvisc.c_str());
+  output::fyvisc.open(outyvisc.c_str());
+  output::fdiagvisc.open(outdiagvisc.c_str());
+  output::faniz.open(outaniz.c_str());
+  //################################################################
+  // important remark. for correct diagonal output, nx=ny must hold.
+  //################################################################
+  outputGnuplot(tau0);
+  output::faniz << "#  tau  <<v_T>>  e_p  e'_p  (to compare with SongHeinz)\n";
+ }
 }
 
 void Fluid::correctImagCells(void) {
@@ -424,7 +428,7 @@ void Fluid::outputGnuplot(double tau) {
  output::fz << endl;
 }
 
-// unput: geom. rapidity + velocities in Bjorken frame, --> output: velocities
+// input: geom. rapidity + velocities in Bjorken frame, --> output: velocities
 // in lab.frame
 void transformToLab(double eta, double &vx, double &vy, double &vz) {
  const double Y = eta + 1. / 2. * log((1. + vz) / (1. - vz));
@@ -441,7 +445,7 @@ void Fluid::outputSurface(double tau) {
         txxyy_num = 0., txxyy_den = 0., Nb1 = 0., Nb2 = 0.,
         eps_p = 0. ;
  double eta = 0;
- int nelements = 0, nsusp = 0;  // all surface emenents and suspicious ones
+ int nelements = 0, nsusp = 0;  // all surface elements and suspicious ones
  int nCoreCells = 0,
      nCoreCutCells = 0;  // cells with e>eCrit and cells with cut visc.corr.
                          //-- Cornelius: allocating memory for corner points

--- a/src/fld.h
+++ b/src/fld.h
@@ -27,7 +27,7 @@ public:
        int _nz, double _minx, double _maxx, double _miny, double _maxy,
        double _minz, double _maxz, double dt, double eCrit);
  ~Fluid();
- void initOutput(const char *dir, double tau0);
+ void initOutput(const char *dir, double tau0, bool hsOnly);
  int output_xy_spacing;
  int output_eta_points;
  int output_tau_spacing;


### PR DESCRIPTION
Option freezeoutOnly is added as a possible parameter read in from the input parameter file. When freezeoutOnly = 1, only the output file containing the hypersurface "freezeout.dat" is produced. Default value is False.