### PR TITLE
Add Qh correction at the boundary

### DIFF
--- a/src/fld.cpp
+++ b/src/fld.cpp
@@ -158,7 +158,7 @@ void Fluid::initOutput(const char *dir, double tau0, bool hsOnly) {
 }
 
 void Fluid::correctImagCells(void) {
- double Q[7];
+ double Q[7], Qh[7];
  // Z
  for (int ix = 0; ix < nx; ix++)
   for (int iy = 0; iy < ny; iy++) {
@@ -166,10 +166,18 @@ void Fluid::correctImagCells(void) {
    getCell(ix, iy, 2)->getQ(Q);
    getCell(ix, iy, 1)->setQ(Q);
    getCell(ix, iy, 0)->setQ(Q);
+
+   getCell(ix, iy, 2)->getQh(Qh);
+   getCell(ix, iy, 1)->setQh(Qh);
+   getCell(ix, iy, 0)->setQh(Qh);
    // right boundary
    getCell(ix, iy, nz - 3)->getQ(Q);
    getCell(ix, iy, nz - 2)->setQ(Q);
    getCell(ix, iy, nz - 1)->setQ(Q);
+
+   getCell(ix, iy, nz - 3)->getQh(Qh);
+   getCell(ix, iy, nz - 2)->setQh(Qh);
+   getCell(ix, iy, nz - 1)->setQh(Qh);
   }
  // Y
  for (int ix = 0; ix < nx; ix++)
@@ -178,10 +186,18 @@ void Fluid::correctImagCells(void) {
    getCell(ix, 2, iz)->getQ(Q);
    getCell(ix, 1, iz)->setQ(Q);
    getCell(ix, 0, iz)->setQ(Q);
+
+   getCell(ix, 2, iz)->getQh(Qh);
+   getCell(ix, 1, iz)->setQh(Qh);
+   getCell(ix, 0, iz)->setQh(Qh);
    // right boundary
    getCell(ix, ny - 3, iz)->getQ(Q);
    getCell(ix, ny - 2, iz)->setQ(Q);
    getCell(ix, ny - 1, iz)->setQ(Q);
+
+   getCell(ix, ny - 3, iz)->getQh(Qh);
+   getCell(ix, ny - 2, iz)->setQh(Qh);
+   getCell(ix, ny - 1, iz)->setQh(Qh);
   }
  // X
  for (int iy = 0; iy < ny; iy++)
@@ -190,10 +206,18 @@ void Fluid::correctImagCells(void) {
    getCell(2, iy, iz)->getQ(Q);
    getCell(1, iy, iz)->setQ(Q);
    getCell(0, iy, iz)->setQ(Q);
+
+   getCell(2, iy, iz)->getQh(Qh);
+   getCell(1, iy, iz)->setQh(Qh);
+   getCell(0, iy, iz)->setQh(Qh);
    // right boundary
    getCell(nx - 3, iy, iz)->getQ(Q);
    getCell(nx - 2, iy, iz)->setQ(Q);
    getCell(nx - 1, iy, iz)->setQ(Q);
+
+   getCell(nx - 3, iy, iz)->getQh(Qh);
+   getCell(nx - 2, iy, iz)->setQh(Qh);
+   getCell(nx - 1, iy, iz)->setQh(Qh);
   }
 }
 

--- a/src/fld.h
+++ b/src/fld.h
@@ -59,8 +59,8 @@ public:
   return &cell[ix + nx * iy + nx * ny * iz];
  }
 
- void correctImagCells(void);      // only ideal hydro part
- void correctImagCellsFull(void);  // correct ideal+visc
+ void correctImagCells(void);      // only ideal hydro part, Q + Qh
+ void correctImagCellsFull(void);  // correct ideal+viscous, Q + pi
  void updateM(double tau, double dt);
 
  void outputGnuplot(double tau);


### PR DESCRIPTION
In Fluid::correctImagCells the half-step quantities Qh are corrected in order not to generate viscous fluxes at the boundary