### PR TITLE
Include VTK output during hydrodynamic evolution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ vpath %.cpp src
 objdir     = obj
 
 SRC        = cll.cpp eos.cpp eo3.cpp eo1.cpp eoChiral.cpp eoHadron.cpp eoAZH.cpp eoSmash.cpp trancoeff.cpp fld.cpp hdo.cpp s95p.cpp icurqmd.cpp ic.cpp ickw.cpp icPartUrqmd.cpp icPartSMASH.cpp main.cpp rmn.cpp cornelius.cpp \
-             icGlauber.cpp icGubser.cpp icGlissando.cpp icTrento.cpp
+             icGlauber.cpp icGubser.cpp icGlissando.cpp icTrento.cpp vtk.cpp
 OBJS       = $(patsubst %.cpp,$(objdir)/%.o,$(SRC))
 
 TARGET	   = hlle_visc

--- a/src/hdo.h
+++ b/src/hdo.h
@@ -20,7 +20,7 @@ public:
  void setDtau(double deltaTau);  // change the timestep
  double getDtau() { return dt; }  // return current value of timestep
  void setFluid(Fluid *_f) { f = _f; }
- Fluid* getFluid() { return f; }
+ Fluid* getFluid()  const { return f; }
 
  // HLLE (ideal)flux between two neighbouring cells in a given direction
  // mode: PREDICT = used in predictor step; calculates fluxes for dt/2
@@ -50,5 +50,5 @@ public:
  // source terms) over one timestep
  void performStep(void);
  // gets the current proper time
- inline double getTau() { return tau; }
+ inline double getTau() const { return tau; }
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,6 +39,7 @@
 #include "eoHadron.h"
 #include "eoSmash.h"
 #include "trancoeff.h"
+#include "vtk.h"
 
 using namespace std;
 
@@ -310,11 +311,19 @@ int main(int argc, char **argv) {
 
  f->initOutput(outputDir.c_str(), tau0);
  f->outputCorona(tau0);
-
+ bool vtk=true;
  bool resized = false; // flag if the grid has been resized
+ std::string a="test";
+ std::string b="test";
+ std::string c="test";
+ VtkOutput vtk_out=VtkOutput(a,b,c);
+
  do {
   // small tau: decrease timestep by makins substeps, in order
   // to avoid instabilities in eta direction (signal velocity ~1/tau)
+  if(vtk) {
+    vtk_out.write(*h);
+  }
   int nSubSteps = 1;
   while (dtau / nSubSteps >
          1.0 * h->getTau() * (etamax - etamin) / (nz - 1)) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,6 +50,7 @@ int eosTypeHadron = 0;
 double xmin, xmax, ymin, ymax, etamin, etamax, tau0, tauMax, tauResize, dtau;
 string collSystem, outputDir, isInputFile;
 double etaS, zetaS, eCrit;
+bool vtk_cartesian=false;
 int icModel, glauberVariable = 1;  // icModel=1 for pure Glauber, 2 for table input (Glissando etc)
 double epsilon0, Rgt, Rgz, impactPar, s0ScaleFactor;
 std::string vtk_values;
@@ -126,6 +127,8 @@ void readParameters(char *parFile) {
    vtk = atoi(parValue);
   else if (strcmp(parName, "VTK_output_values") == 0)
    vtk_values = parValue;
+  else if (strcmp(parName, "VTK_cartesian") == 0)
+   vtk_cartesian = parValue;
   else if (parName[0] == '!')
    cout << "CCC " << sline.str() << endl;
   else
@@ -164,6 +167,7 @@ void printParameters() {
  cout << "s0ScaleFactor = " << s0ScaleFactor << endl;
  cout << "VTK output = " << vtk << endl;
  cout << "VTK output values = " << vtk_values << endl;
+ cout << "VTK cartesian = " << vtk_cartesian << endl;
  cout << "======= end parameters =======\n";
 }
 
@@ -322,7 +326,7 @@ int main(int argc, char **argv) {
  bool resized = false; // flag if the grid has been resized
  
  std::string dir=outputDir.c_str();
- VtkOutput vtk_out=VtkOutput(dir,eos,xmin,ymin,etamin);
+ VtkOutput vtk_out=VtkOutput(dir,eos,xmin,ymin,etamin, vtk_cartesian);
 
  do {
   // small tau: decrease timestep by makins substeps, in order

--- a/src/vtk.cpp
+++ b/src/vtk.cpp
@@ -1,0 +1,54 @@
+#include "vtk.h"
+#include <stdexcept>
+
+/*struct FileDeleter {
+  /// The class has no members, so this is a noop.
+  constexpr FileDeleter() = default;
+
+  
+  void operator()(std::FILE* f) const {
+    if (f == nullptr) {
+      return;
+    }
+    if (0 != std::fclose(f)) {
+      throw std::runtime_error(std::strerror(errno));
+    }
+  }
+};
+
+using FilePtr = std::unique_ptr<std::FILE, FileDeleter>;*/
+
+VtkOutput::VtkOutput(const std::string &path, const std::string &name,
+                     const std::string &out_par)
+    : name(name),
+      base_path_(path){}
+
+VtkOutput::~VtkOutput() {}
+
+
+void VtkOutput::write_header(std::ofstream &file, Hydro &h, const std::string &description){
+    file << "# vtk DataFile Version 2.0\n"
+       << description << "\n";
+       //<< "ASCII\n"
+       //<< "DATASET STRUCTURED_POINTS\n"
+       //<< "DIMENSIONS " << dim[0] << " " << dim[1] << " " << dim[2] << "\n"
+       //<< "SPACING " << cs[0] << " " << cs[1] << " " << cs[2] << "\n"
+       //<< "ORIGIN " << orig[0] << " " << orig[1] << " " << orig[2] << "\n"
+       //<< "POINT_DATA " << lattice.size() << "\n";
+    return;
+}
+
+std::string VtkOutput::make_filename(const std::string &descr, int counter) {
+  char suffix[22];
+  snprintf(suffix, sizeof(suffix), "_tstep%05i.vtk",counter);
+  return base_path_ + std::string("/") + descr + std::string(suffix);
+}
+
+void VtkOutput::write(Hydro &h){
+    char filename[32];
+    std::string t="test";
+    std::ofstream file;
+    file.open(make_filename(t, vtk_output_counter_++), std::ios::out);
+    write_header(file, h, t);
+    return;
+}

--- a/src/vtk.cpp
+++ b/src/vtk.cpp
@@ -1,54 +1,142 @@
 #include "vtk.h"
+#include "hdo.h"
+#include "fld.h"
+
 #include <stdexcept>
+#include <iostream>
+#include <sstream>
+#include <vector>
 
-/*struct FileDeleter {
-  /// The class has no members, so this is a noop.
-  constexpr FileDeleter() = default;
-
-  
-  void operator()(std::FILE* f) const {
-    if (f == nullptr) {
-      return;
-    }
-    if (0 != std::fclose(f)) {
-      throw std::runtime_error(std::strerror(errno));
-    }
-  }
-};
-
-using FilePtr = std::unique_ptr<std::FILE, FileDeleter>;*/
-
-VtkOutput::VtkOutput(const std::string &path, const std::string &name,
-                     const std::string &out_par)
-    : name(name),
-      base_path_(path){}
-
-VtkOutput::~VtkOutput() {}
-
-
-void VtkOutput::write_header(std::ofstream &file, Hydro &h, const std::string &description){
+void VtkOutput::write_header(std::ofstream &file, const Hydro h, const std::string &description){
+  if(cartesian_){
     file << "# vtk DataFile Version 2.0\n"
-       << description << "\n";
-       //<< "ASCII\n"
-       //<< "DATASET STRUCTURED_POINTS\n"
-       //<< "DIMENSIONS " << dim[0] << " " << dim[1] << " " << dim[2] << "\n"
-       //<< "SPACING " << cs[0] << " " << cs[1] << " " << cs[2] << "\n"
-       //<< "ORIGIN " << orig[0] << " " << orig[1] << " " << orig[2] << "\n"
-       //<< "POINT_DATA " << lattice.size() << "\n";
-    return;
+      << description << "\n"
+      << "ASCII\n"
+      << "DATASET STRUCTURED_POINTS\n"
+      << "DIMENSIONS " << h.getFluid()->getNX() << " " << h.getFluid()->getNY() << " " << (h.getFluid()->getNZ())*20 << "\n"
+      << "SPACING " << h.getFluid()->getDx() << " " << h.getFluid()->getDy() << " " << h.getTau()*std::sinh(h.getFluid()->getDz()*(h.getFluid()->getNZ()/2))/(20*h.getFluid()->getNZ()/2) << "\n"
+      << "ORIGIN " << xmin_ << " " << ymin_ << " " << zmin_ << "\n"
+      << "POINT_DATA " << h.getFluid()->getNX()*h.getFluid()->getNY()*(h.getFluid()->getNZ())*20<< "\n";
+  }else{
+    file << "# vtk DataFile Version 2.0\n"
+      << description << "\n"
+      << "ASCII\n"
+      << "DATASET STRUCTURED_POINTS\n"
+      << "DIMENSIONS " << h.getFluid()->getNX() << " " << h.getFluid()->getNY() << " " << h.getFluid()->getNZ() << "\n"
+      << "SPACING " << h.getFluid()->getDx() << " " << h.getFluid()->getDy() << " " << h.getFluid()->getDz() << "\n"
+      << "ORIGIN " << xmin_ << " " << ymin_ << " " << zmin_ << "\n"
+      << "POINT_DATA " << h.getFluid()->getNX()*h.getFluid()->getNY()*h.getFluid()->getNZ() << "\n";
+  }
+  
+  return;
 }
 
 std::string VtkOutput::make_filename(const std::string &descr, int counter) {
-  char suffix[22];
-  snprintf(suffix, sizeof(suffix), "_tstep%05i.vtk",counter);
-  return base_path_ + std::string("/") + descr + std::string(suffix);
+  char suffix[24];
+  snprintf(suffix, sizeof(suffix), "_taustep%05i.vtk",counter);
+  return path_ + std::string("/") + descr + std::string(suffix);
 }
 
-void VtkOutput::write(Hydro &h){
-    char filename[32];
-    std::string t="test";
+void VtkOutput::write_vtk_scalar(std::ofstream &file, const Hydro h, std::string &quantity) {
+  file << "SCALARS " << quantity << " double 1\n"
+       << "LOOKUP_TABLE default\n";
+  file << std::setprecision(3);
+  file << std::fixed;
+  int z_length;
+  if(cartesian_){
+    z_length=20*(h.getFluid()->getNZ());
+  }else{
+    z_length=h.getFluid()->getNZ();
+  }
+  
+  for (int iz = 0; iz < z_length; iz++) {
+    double poseta=iz;
+    double factor=1;
+    if(cartesian_){
+      double total_length=h.getTau()*std::sinh(h.getFluid()->getDz()*(h.getFluid()->getNZ()/2));
+      double pos;
+      if(iz<z_length/2){
+        pos=-total_length+total_length/(z_length/2)*iz;
+        for (int ieta=0; ieta< h.getFluid()->getNZ()/2; ieta++){
+        if(h.getTau()*std::sinh(h.getFluid()->getDz()*(ieta-h.getFluid()->getNZ()/2))>pos){
+          factor=fabs((h.getTau()*std::sinh(h.getFluid()->getDz()*(ieta-h.getFluid()->getNZ()/2))-pos)/pos);
+          poseta=ieta;
+          break;
+        }
+      }
+      }else{
+        pos=total_length/(z_length/2)*(iz-z_length/2);
+        for (int ieta=h.getFluid()->getNZ()/2; ieta<h.getFluid()->getNZ() ; ieta++){
+        if(h.getTau()*std::sinh(h.getFluid()->getDz()*(ieta-h.getFluid()->getNZ()/2))>pos){
+          factor=fabs((h.getTau()*std::sinh(h.getFluid()->getDz()*(ieta-h.getFluid()->getNZ()/2))-pos)/pos);
+          poseta=ieta;
+          break;
+        }
+      }
+      }
+      if(pos==0){
+        factor=1;
+      }
+     }
+   
+    for (int iy = 0; iy < h.getFluid()->getNY(); iy++) {
+      for (int ix = 0; ix < h.getFluid()->getNX(); ix++) {
+         double e,p,nb,nq,ns,vx,vy,vz;
+         double e2,p2,nb2,nq2,ns2,vx2,vy2,vz2;
+         Cell* cell=h.getFluid()->getCell(ix,iy,poseta);
+         Cell* cell2;
+         if(poseta>0){
+           cell2=h.getFluid()->getCell(ix,iy,poseta-1);
+         }else{
+           cell2=cell;
+         }
+         cell->getPrimVar(eos_, h.getTau(), e, p, nb, nq, ns, vx, vy, vz);
+         cell2->getPrimVar(eos_, h.getTau(), e2, p2, nb2, nq2, ns2, vx2, vy2, vz2);
+         double q=0;
+         if (quantity=="eps"){
+           q=factor*e+(factor-1)*e2;
+         } else if (quantity == "p"){
+           q=factor*p+(factor-1)*p2;
+         } else if (quantity =="nb"){
+           q=factor*nb+(factor-1)*nb2;
+         } else if (quantity =="nq"){
+           q=factor*nq+(factor-1)*nq2;
+         } else if(quantity == "ns"){
+           q=factor*ns+(factor-1)*ns2;
+         }else{
+          std::cout<<"No quantity for VTK output specified"<<std::endl;
+          return;
+         }
+         file << q << " ";
+      }
+      file << "\n"; 
+    }
+  }
+}
+
+std::vector<std::string> split (const std::string &s, char delim) {
+  std::vector<std::string> result;
+  std::stringstream ss (s);
+  std::string item;
+
+  while (getline (ss, item, delim)) {
+      result.push_back (item);
+  }
+
+  return result;
+}
+
+void VtkOutput::write(const Hydro h, std::string &quantity){
+  std::vector<std::string> quantity_list=split(quantity,',');
+  vtk_output_counter_++;
+  for (auto q : quantity_list){
+    std::string t=q;
     std::ofstream file;
-    file.open(make_filename(t, vtk_output_counter_++), std::ios::out);
+
+    file.open(make_filename(t, vtk_output_counter_), std::ios::out);
     write_header(file, h, t);
-    return;
+    write_vtk_scalar(file, h, q);
+  }
+  
+  return;
 }

--- a/src/vtk.h
+++ b/src/vtk.h
@@ -1,0 +1,36 @@
+#include <iostream>
+#include <fstream>
+#include <iomanip>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <utility>
+
+class Hydro;
+
+
+
+class VtkOutput {
+ public:
+  /**
+   * Create a new VTK output.
+   *
+   * \param path Path to the output file.
+   * \param name Name of the output.
+   * \param out_par Additional information on the configured output.
+   */
+  VtkOutput(const std::string &path, const std::string &name,
+            const std::string &out_par);
+  ~VtkOutput();
+
+  void write(Hydro &h);
+  void write_header(std::ofstream &file, Hydro &h, const std::string &description);
+  std::string make_filename (const std::string &descr, int counter);
+
+  private:
+
+  const std::string base_path_;
+  const std::string name;
+  /// Number of vtk output in current event
+  int vtk_output_counter_ = -1;
+};

--- a/src/vtk.h
+++ b/src/vtk.h
@@ -6,11 +6,23 @@
 #include <string>
 #include <utility>
 
+class Cell;
+class Fluid;
+class EoS;
 class Hydro;
 
-
-
 class VtkOutput {
+
+ private:
+
+ std::string  path_;
+ /// Number of vtk output in current event
+ int vtk_output_counter_ = -1;
+ EoS* eos_;
+ bool cartesian_;
+ double xmin_, ymin_,zmin_;
+
+
  public:
   /**
    * Create a new VTK output.
@@ -19,18 +31,19 @@ class VtkOutput {
    * \param name Name of the output.
    * \param out_par Additional information on the configured output.
    */
-  VtkOutput(const std::string &path, const std::string &name,
-            const std::string &out_par);
-  ~VtkOutput();
+  VtkOutput( std::string  path, EoS* eos, double xmin,double ymin,double zmin, bool cartesian=false):
+              path_(path),
+              eos_(eos),
+              cartesian_(cartesian),
+              xmin_(xmin),
+              ymin_(ymin),
+              zmin_(zmin)
+            {}
 
-  void write(Hydro &h);
-  void write_header(std::ofstream &file, Hydro &h, const std::string &description);
+  void write(const Hydro h, std::string &quantity);
+  void write_header(std::ofstream &file, const Hydro h,  const std::string &description);
+  void write_vtk_scalar(std::ofstream &file, const Hydro h, std::string &quantity);
   std::string make_filename (const std::string &descr, int counter);
 
-  private:
-
-  const std::string base_path_;
-  const std::string name;
-  /// Number of vtk output in current event
-  int vtk_output_counter_ = -1;
+  
 };


### PR DESCRIPTION
This PR introduces an optional VTK output, which allows to visualize the evolution. This can be used by visualization programs like Paraview. The quantities to be visualised are energy density, pressure and the different charges. With this PR, 3 new config options are included: one to turn on/off VTK output (default: off), one which defines the value to be printed and one which changes the default Milner coordinates to cartesian coordinates (relevant for very low energies only).