### PR TITLE
Tag freezeout output file as unfinished

### DIFF
--- a/src/fld.cpp
+++ b/src/fld.cpp
@@ -20,6 +20,7 @@
 #include <iomanip>
 #include <cmath>
 #include <algorithm>
+#include <cstdio>
 #include "inc.h"
 #include "rmn.h"
 #include "fld.h"
@@ -27,6 +28,7 @@
 #include "eos.h"
 #include "trancoeff.h"
 #include "cornelius.h"
+#include "colour.h"
 
 #define OUTPI
 
@@ -120,6 +122,9 @@ void Fluid::initOutput(const char *dir, double tau0, bool hsOnly) {
  cout << "mkdir returns: " << return_mkdir << endl;
  string outfreeze = dir;
  outfreeze.append("/freezeout.dat");
+ checkOutputDirectory(outfreeze,"");
+ outfreeze.append(".unfinished");
+ checkOutputDirectory(outfreeze,".unfinished");
  output::ffreeze.open(outfreeze.c_str());
  if (!hsOnly) {
   string outx = dir;
@@ -155,6 +160,29 @@ void Fluid::initOutput(const char *dir, double tau0, bool hsOnly) {
   outputGnuplot(tau0);
   output::faniz << "#  tau  <<v_T>>  e_p  e'_p  (to compare with SongHeinz)\n";
  }
+}
+
+void Fluid::renameOutput(const char *dir) {
+  // renames hypersurface output in case of clean exit
+  std::string directory = dir;
+  std::string oldFile = directory + "/freezeout.dat.unfinished";
+  std::string newFile = directory + "/freezeout.dat";
+  if (std::rename(oldFile.c_str(), newFile.c_str()) != 0)
+		perror("Error renaming freezeout.dat.unfinished!");
+}
+
+void Fluid::checkOutputDirectory(std::string freezeoutFile, std::string suffix) {
+  // remove old freezeout.dat(.unfinished) file
+  std::string checkFilePresent = "[ -f " + freezeoutFile + " ]";
+  int isFileThere = system(checkFilePresent.c_str());
+  if (isFileThere == 0) {
+    std::string file_warning = "Warning! A 'freezeout.dat" + suffix +
+                               "' is present in your output directory.\n" +
+                               "         It will be deleted automatically.\n";
+    std::cout << yellow << file_warning << reset;
+    std:string deleteFile = "rm " + freezeoutFile;
+    int isDeleted = system(deleteFile.c_str());
+  }
 }
 
 void Fluid::correctImagCells(void) {

--- a/src/fld.cpp
+++ b/src/fld.cpp
@@ -21,6 +21,7 @@
 #include <cmath>
 #include <algorithm>
 #include <cstdio>
+#include <filesystem>
 #include "inc.h"
 #include "rmn.h"
 #include "fld.h"
@@ -116,15 +117,13 @@ Fluid::~Fluid() {
 void Fluid::initOutput(const char *dir, double tau0, bool hsOnly) {
  // hsOnly (default false):
  // if true only the hypersurface output is initialized
- char command[255];
- sprintf(command, "mkdir -p %s", dir);
- int return_mkdir = system(command);
+ std::string outfreeze = dir;
+ bool return_mkdir = std::filesystem::create_directory(outfreeze);
  cout << "mkdir returns: " << return_mkdir << endl;
- string outfreeze = dir;
  outfreeze.append("/freezeout.dat");
- checkOutputDirectory(outfreeze,"");
+ checkOutputDirectory(outfreeze);
  outfreeze.append(".unfinished");
- checkOutputDirectory(outfreeze,".unfinished");
+ checkOutputDirectory(outfreeze);
  output::ffreeze.open(outfreeze.c_str());
  if (!hsOnly) {
   string outx = dir;
@@ -171,17 +170,16 @@ void Fluid::renameOutput(const char *dir) {
 		perror("Error renaming freezeout.dat.unfinished!");
 }
 
-void Fluid::checkOutputDirectory(std::string freezeoutFile, std::string suffix) {
+void Fluid::checkOutputDirectory(std::string freezeoutFile) {
   // remove old freezeout.dat(.unfinished) file
-  std::string checkFilePresent = "[ -f " + freezeoutFile + " ]";
-  int isFileThere = system(checkFilePresent.c_str());
-  if (isFileThere == 0) {
-    std::string file_warning = "Warning! A 'freezeout.dat" + suffix +
+  bool isFilePresent = std::filesystem::exists(freezeoutFile);
+  std::string filename = std::filesystem::path(freezeoutFile).filename();
+  if (isFilePresent) {
+    std::string file_warning = "Warning! A '" + filename +
                                "' is present in your output directory.\n" +
                                "         It will be deleted automatically.\n";
     std::cout << yellow << file_warning << reset;
-    std:string deleteFile = "rm " + freezeoutFile;
-    int isDeleted = system(deleteFile.c_str());
+    bool isDeleted = std::filesystem::remove(freezeoutFile);
   }
 }
 

--- a/src/fld.h
+++ b/src/fld.h
@@ -29,7 +29,7 @@ public:
  ~Fluid();
  void initOutput(const char *dir, double tau0, bool hsOnly);
  void renameOutput(const char *dir);
- void checkOutputDirectory(std::string freezeoutFile, std::string suffix);
+ void checkOutputDirectory(std::string freezeoutFile);
  int output_xy_spacing;
  int output_eta_points;
  int output_tau_spacing;

--- a/src/fld.h
+++ b/src/fld.h
@@ -28,6 +28,8 @@ public:
        double _minz, double _maxz, double dt, double eCrit);
  ~Fluid();
  void initOutput(const char *dir, double tau0, bool hsOnly);
+ void renameOutput(const char *dir);
+ void checkOutputDirectory(std::string freezeoutFile, std::string suffix);
  int output_xy_spacing;
  int output_eta_points;
  int output_tau_spacing;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -446,6 +446,8 @@ int main(int argc, char **argv) {
  float diff2 = difftime(end, start);
  cout << "Execution time = " << diff2 << " [sec]" << endl;
 
+ f->renameOutput(outputDir.c_str());
+
  delete f;
  delete h;
  delete eos;


### PR DESCRIPTION
This PR contains two output file operation changes: 
- freezeout.dat.unfinished is opened at first, renamed freezeout.dat only after the hydrodynamic loop is finished
- outputDir is checked for freezeout.dat and freezeout.dat.unfinished and these are deleted before ouput is inicialized (with a warning)