### PR TITLE
Optional vorticity output in stable_ebe

### DIFF
--- a/src/cll.cpp
+++ b/src/cll.cpp
@@ -49,6 +49,10 @@ Cell::Cell() {
  Pi0 = 0.0;
  PiH0 = 0.0;
  setAllM(0.);
+ // allocate memory for the vorticity tensor if vorticity is enabled
+ if(vorticityOn) {
+     dbeta = std::make_unique<Matrix2D>(4, std::vector<double>(4));
+ }
 }
 
 void Cell::importVars(Cell* c) {

--- a/src/cll.cpp
+++ b/src/cll.cpp
@@ -49,10 +49,6 @@ Cell::Cell() {
  Pi0 = 0.0;
  PiH0 = 0.0;
  setAllM(0.);
- // allocate memory for the vorticity tensor if vorticity is enabled
- if(vorticityOn) {
-     dbeta = std::make_unique<Matrix2D>(4, std::vector<double>(4));
- }
 }
 
 void Cell::importVars(Cell* c) {

--- a/src/cll.h
+++ b/src/cll.h
@@ -161,10 +161,10 @@ public:
    for (int j = 0; j < 4; j++) piH0[index44(i, j)] = values[i][j];
  }
 
- inline void setDbeta(const double (&values)[4][4]) {
+ inline void setDbeta(const std::unique_ptr<Matrix2D> &values) {
     for (int i = 0; i < 4; i++)
       for (int j = 0; j < 4; j++) {
-       (*dbeta)[i][j] = (*dbeta)[i][j];
+       (*dbeta)[i][j] = (*values)[i][j];
        (*dbeta)[i][j] = std::min((*dbeta)[i][j], 100.);
        (*dbeta)[i][j] = std::max((*dbeta)[i][j], -100.);
       }

--- a/src/cll.h
+++ b/src/cll.h
@@ -18,9 +18,14 @@
 #pragma once
 #include <iosfwd>
 #include <algorithm>
+#include <memory>
 #include <cmath>
 #include "inc.h"
 class EoS;
+
+// Alias for a 2D matrix and a cube holding one Matrix2D per cell 
+using Matrix2D = std::vector<std::vector<double>>;
+using Cube = std::vector<std::vector<std::vector<Matrix2D>>>;
 
 //#define NAN_DEBUG
 
@@ -32,24 +37,26 @@ class Cell {
 private:
  // Q usually denotes the conserved quantities, T^{0i}
  // here, Q, Qh, Qprev etc. ~tau*T^{0i}, like Hirano'01
- double Q[7];      // final values at a given timestep
- double Qh[7];     // half-step updated values
- double Qprev[7];  // values at the end of previous timestep
- double pi[10], piH[10];  // pi^{mu nu}, WITHOUT tau factor, final (pi) and
-                          // half-step updated (piH)
- double Pi,
-     PiH;  // Pi, WITHOUT tau factor, final (Pi) and half-step updated (PiH)
- double pi0[10], piH0[10];  // // pi^{mu nu}, WITHOUT tau factor, auxiliary
- double Pi0, PiH0;          // viscous, WITHOUT tau factor, auxiliary
- double flux[7];            // cumulative fluxes
- Cell *next[3];             // pointer to the next cell in a given direction
- Cell *prev[3];             // pointer to the previous cell in a given direction
- double m[3];               // extend of matter propagation inside cell [0...1]
- double dm[3];              // auxiliary
- int ix, iy, iz;            // cell coordinate on the grid
+ double Q[7];                     // final values at a given timestep
+ double Qh[7];                    // half-step updated values
+ double Qprev[7];                 // values at the end of previous timestep
+ double pi[10], piH[10];          // pi^{mu nu}, WITHOUT tau factor, final (pi)
+                                  // and half-step updated (piH)
+ double Pi, PiH;                  // Pi, WITHOUT tau factor, final (Pi) and half-step updated (PiH)
+ double pi0[10], piH0[10];        // pi^{mu nu}, WITHOUT tau factor, auxiliary
+ double Pi0, PiH0;                // viscous, WITHOUT tau factor, auxiliary
+ std::unique_ptr<Matrix2D> dbeta; // dynamically allocated 2D (4x4) array for the 
+                                  // vorticity tensor flattened into a 1D array
+ double flux[7];                  // cumulative fluxes
+ Cell *next[3];                   // pointer to the next cell in a given direction
+ Cell *prev[3];                   // pointer to the previous cell in a given direction
+ double m[3];                     // extend of matter propagation inside cell [0...1]
+ double dm[3];                    // auxiliary
+ int ix, iy, iz;                  // cell coordinate on the grid
  // viscCorrCut: flag if the viscous corrections are cut for this cell:
  // 1.0 = uncut, < 1 :  cut by this factor
  double viscCorrCut;
+ bool vorticityOn = false;        // flag indicating if vorticity is enabled
 
 public:
  Cell();
@@ -154,6 +161,24 @@ public:
    for (int j = 0; j < 4; j++) piH0[index44(i, j)] = values[i][j];
  }
 
+ inline void setDbeta(const double (&values)[4][4]) {
+    for (int i = 0; i < 4; i++)
+      for (int j = 0; j < 4; j++) {
+       (*dbeta)[i][j] = (*dbeta)[i][j];
+       (*dbeta)[i][j] = std::min((*dbeta)[i][j], 100.);
+       (*dbeta)[i][j] = std::max((*dbeta)[i][j], -100.);
+      }
+  }
+
+  inline void resetDbeta() {
+    for (int i = 0; i < 4; i++)
+      for (int j = 0; j < 4; j++) (*dbeta)[i][j] = 0.0;
+  }
+
+ inline double getDbeta(int i, int j) {
+  return (*dbeta)[i][j];
+ }
+
  // get the energy density, pressure, charge densities and flow velocity
  // components (e,p,n,v) from conserved quantities Q in the centre of the cell
  void getPrimVar(EoS *eos, double tau, double &_e, double &_p, double &_nb,
@@ -189,6 +214,9 @@ public:
  // calculate and set Q from (e,n,v)
  void setPrimVar(EoS *eos, double tau, double _e, double _nb, double _nq,
                  double _ns, double _vx, double _vy, double _vz);
+
+ // enable vorticity in the cell
+ inline void enableVorticity() { vorticityOn = true; }
 
  // update the cumulative fluxes through the cell
  inline void addFlux(double Ft, double Fx, double Fy, double Fz, double Fnb,

--- a/src/cll.h
+++ b/src/cll.h
@@ -25,7 +25,7 @@ class EoS;
 
 // Alias for a 2D matrix and a cube holding one Matrix2D per cell 
 using Matrix2D = std::vector<std::vector<double>>;
-using Cube = std::vector<std::vector<std::vector<Matrix2D>>>;
+using Block3D = std::vector<std::vector<std::vector<Matrix2D>>>;
 
 //#define NAN_DEBUG
 

--- a/src/fld.cpp
+++ b/src/fld.cpp
@@ -23,6 +23,7 @@
 #include <memory>
 #include <cstdio>
 #include <filesystem>
+#include <stdexcept>
 #include "inc.h"
 #include "rmn.h"
 #include "fld.h"
@@ -626,8 +627,13 @@ int Fluid::outputSurface(double tau, bool extendFO) {
         }
        }
        PiSquare[jx][jy][jz] = cc->getPi();
+
        // ---- get dbeta if enabled
        if(vorticityOn) {
+        // ensure that dbetaBlock is allocated
+        if(!dbetaBlock) {
+          std::runtime_error("dbetaBlock is a nullptr");
+        }
         for(int column = 0 ; column < 4 ; column++) {
           for(int row = 0 ; row < 4 ; row++) {
             (*dbetaBlock)[jx][jy][jz][column][row] = cc -> getDbeta(column, row);
@@ -698,6 +704,10 @@ int Fluid::outputSurface(double tau, bool extendFO) {
         }
          PiC += PiSquare[jx][jy][jz] * wCenX[jx] * wCenY[jy] * wCenZ[jz];
          if (vorticityOn) {
+          // ensure that dbetaBlock is allocated
+          if(!dbetaInterpolated) {
+            std::runtime_error("dbetaInterpolated is a nullptr");
+          }
           for(int column = 0 ; column < 4 ; column++) {
             for(int row = 0 ; row < 4 ; row++) {
               (*dbetaInterpolated)[column][row] +=
@@ -792,6 +802,10 @@ int Fluid::outputSurface(double tau, bool extendFO) {
        : nullptr;
 
      if(vorticityOn) {
+      // ensure that dbetaCartesian and jacobian are allocated
+      if (!dbetaCartesian || !jacobian) {
+        std::runtime_error("dbetaCartesian and/or jacobian is a nullptr");
+      }
       for (int i = 0; i < 4; i++) {
         for (int j = 0; j < 4; j++) {
           for (int k = 0; k < 4; k++) {

--- a/src/fld.cpp
+++ b/src/fld.cpp
@@ -95,7 +95,6 @@ Fluid::Fluid(EoS *_eos, EoS *_eosH, TransportCoeff *_trcoeff, int _nx, int _ny,
     getCell(ix, iy, iz)->setPrev(Z_, getCell(ix, iy, iz - 1));
     getCell(ix, iy, iz)->setNext(Z_, getCell(ix, iy, iz + 1));
     getCell(ix, iy, iz)->setPos(ix, iy, iz);
-    if (vorticityOn) getCell(ix, iy, iz)->enableVorticity();
    }
 
  output_nt = 0;
@@ -594,12 +593,20 @@ int Fluid::outputSurface(double tau, bool extendFO) {
     // each containing a 4x4 matrix (Matrix2D) for dbeta values.
     // Memory allocation occurs only if vorticity is enabled (vorticityOn).
     std::unique_ptr<Block3D> dbetaBlock = vorticityOn
-      ? std::make_unique<Block3D>(2,
-            std::vector<std::vector<Matrix2D>>(2,
-                std::vector<Matrix2D>(2,
-                    Matrix2D(4,
-                        std::vector<double>(4)))))
-      : nullptr;
+    ? std::make_unique<Block3D>(2,
+        std::vector<std::vector<Matrix2D>>(2,
+            std::vector<Matrix2D>(2,
+                Matrix2D{
+                    {0.0, 0.0, 0.0, 0.0},
+                    {0.0, 0.0, 0.0, 0.0},
+                    {0.0, 0.0, 0.0, 0.0},
+                    {0.0, 0.0, 0.0, 0.0}
+                }
+            )
+        )
+    )
+    : nullptr;
+
 
     for (int jx = 0; jx < 2; jx++)
      for (int jy = 0; jy < 2; jy++)
@@ -680,7 +687,7 @@ int Fluid::outputSurface(double tau, bool extendFO) {
      // define a unique pointer to a 4x4 matrix for the interpolated vorticity
      // tensor. Allocation of memory is done only if vorticity is enabled.
      std::unique_ptr<Matrix2D> dbetaInterpolated = vorticityOn
-        ? std::make_unique<Matrix2D>(4, std::vector<double>(4))
+        ? std::make_unique<Matrix2D>(Matrix2D(4, std::vector<double>(4)))
         : nullptr;
 
      for (int jx = 0; jx < 2; jx++)

--- a/src/fld.h
+++ b/src/fld.h
@@ -38,7 +38,18 @@ public:
 
  int output_nt, output_nx, output_ny;
 
- inline void enableVorticity() { vorticityOn = true; }
+ inline void enableVorticity() {
+  vorticityOn = true;
+  // enable vorticity in all cells
+  for (int ix = 0; ix < nx; ix++) {
+    for (int iy = 0; iy < ny; iy++) {
+      for (int iz = 0; iz < nz; iz++) {
+        getCell(ix, iy, iz) -> enableVorticity();
+      }
+    }
+  }
+ }
+
  inline int getNX() { return nx; }
  inline int getNY() { return ny; }
  inline int getNZ() { return nz; }

--- a/src/fld.h
+++ b/src/fld.h
@@ -21,6 +21,7 @@ private:
  double ecrit;
  double vEff, EtotSurf;  // cumulative effective volume and
  int compress2dOut;
+ bool vorticityOn = false;
 
 public:
  Fluid(EoS *_eos, EoS *_eosH, TransportCoeff *_trcoeff, int _nx, int _ny,
@@ -37,6 +38,7 @@ public:
 
  int output_nt, output_nx, output_ny;
 
+ inline void enableVorticity() { vorticityOn = true; }
  inline int getNX() { return nx; }
  inline int getNY() { return ny; }
  inline int getNZ() { return nz; }

--- a/src/hdo.cpp
+++ b/src/hdo.cpp
@@ -20,7 +20,6 @@
 #include <iomanip>
 #include <algorithm>
 #include <unistd.h>
-#include "cll.h"
 #include "hdo.h"
 #include "inc.h"
 #include "rmn.h"

--- a/src/hdo.cpp
+++ b/src/hdo.cpp
@@ -20,12 +20,12 @@
 #include <iomanip>
 #include <algorithm>
 #include <unistd.h>
+#include "cll.h"
 #include "hdo.h"
 #include "inc.h"
 #include "rmn.h"
 #include "fld.h"
 #include "eos.h"
-#include "cll.h"
 #include "trancoeff.h"
 
 using namespace std;
@@ -58,6 +58,12 @@ Hydro::Hydro(Fluid *_f, EoS *_eos, TransportCoeff *_trcoeff, double _t0,
 }
 
 Hydro::~Hydro() {}
+
+void Hydro::enableVorticity() {
+  //enable vorticity in hydro and fluid
+  vorticityOn = true;
+  f->enableVorticity();
+}
 
 void Hydro::setDtau(double deltaTau) {
  dt = deltaTau;
@@ -374,10 +380,11 @@ void Hydro::visc_source_step(int ix, int iy, int iz) {
 // dv/dx_i ~ v^{x+dx}-v{x-dx},
 // which makes sense after non-viscous step
 void Hydro::NSquant(int ix, int iy, int iz, double pi[4][4], double &Pi,
-                    double dmu[4][4], double &du) {
+                    double dmu[4][4], unique_ptr<Matrix2D> &dbeta, double &du) {
  const double VMIN = 1e-2;
  const double UDIFF = 3.0;
  double e0, e1, p, nb, nq, ns, vx1, vy1, vz1, vx0, vy0, vz0, vxH, vyH, vzH;
+ double T, T0, T1, mub, muq, mus;
  double ut0, ux0, uy0, uz0, ut1, ux1, uy1, uz1;
  //	double dmu [4][4] ; // \partial_\mu u^\nu matrix
  // coordinates: 0=tau, 1=x, 2=y, 3=eta
@@ -411,10 +418,15 @@ void Hydro::NSquant(int ix, int iy, int iz, double pi[4][4], double &Pi,
  // centered differences with respect to the values at (it+1/2, ix, iy, iz)
  // d_tau u^\mu
  c->getPrimVarPrev(eos, tau - dt, e0, p, nb, nq, ns, vx0, vy0, vz0);
+ if (vorticityOn) {
+  eos->eos(e0, nb, nq, ns, T0, mub, muq, mus, p);
+ }
  c->getPrimVar(eos, tau, e1, p, nb, nq, ns, vx1, vy1, vz1);
+ if (vorticityOn) {
+   eos->eos(e1, nb, nq, ns, T1, mub, muq, mus, p);
+ }
  c->getPrimVarHCenter(eos, tau - 0.5 * dt, e1, p, nb, nq, ns, vxH, vyH, vzH);
  //############## get transport coefficients
- double T, mub, muq, mus;
  double etaS, zetaS;
  double s = eos->s(e1, nb, nq, ns);  // entropy density in the current cell
  eos->eos(e1, nb, nq, ns, T, mub, muq, mus, p);
@@ -438,6 +450,15 @@ void Hydro::NSquant(int ix, int iy, int iz, double pi[4][4], double &Pi,
  dmu[0][1] = (ux1 * ux1 - ux0 * ux0) / 2. / uuu[1] / dt;
  dmu[0][2] = (uy1 * uy1 - uy0 * uy0) / 2. / uuu[2] / dt;
  dmu[0][3] = (uz1 * uz1 - uz0 * uz0) / 2. / uuu[3] / dt;
+ if (vorticityOn) {
+  (*dbeta)[0][0] = (ut1 / T1 - ut0 / T0) / dt;
+  (*dbeta)[0][1] = (ux1 / T1 - ux0 / T0) / dt;
+  (*dbeta)[0][2] = (uy1 / T1 - uy0 / T0) / dt;
+  (*dbeta)[0][3] = (uz1 / T1 - uz0 / T0) / dt;
+  if(e1 <= 0. || e0 <= 0. || T1<=0. || T0<=0.) {
+    (*dbeta)[0][0] = (*dbeta)[0][1] = (*dbeta)[0][2] = (*dbeta)[0][3] = 0.;
+  }
+ }
  if (fabs(0.5 * (ut1 + ut0) / ut1) > UDIFF) dmu[0][0] = (ut1 - ut0) / dt;
  if (fabs(uuu[1]) < VMIN || fabs(0.5 * (ux1 + ux0) / ux1) > UDIFF)
   dmu[0][1] = (ux1 - ux0) / dt;
@@ -451,8 +472,14 @@ void Hydro::NSquant(int ix, int iy, int iz, double pi[4][4], double &Pi,
  // d_x u^\mu
  f->getCell(ix + 1, iy, iz)
      ->getPrimVarHCenter(eos, tau, e1, p, nb, nq, ns, vx1, vy1, vz1);
+ if (vorticityOn) {
+  eos->eos(e1, nb, nq, ns, T1, mub, muq, mus, p);
+ }
  f->getCell(ix - 1, iy, iz)
      ->getPrimVarHCenter(eos, tau, e0, p, nb, nq, ns, vx0, vy0, vz0);
+ if (vorticityOn) {
+  eos->eos(e0, nb, nq, ns, T0, mub, muq, mus, p);
+ }
  if (e1 > 0. && e0 > 0.) {
   ut0 = 1.0 / sqrt(1.0 - vx0 * vx0 - vy0 * vy0 - vz0 * vz0);
   ux0 = ut0 * vx0;
@@ -466,6 +493,15 @@ void Hydro::NSquant(int ix, int iy, int iz, double pi[4][4], double &Pi,
   dmu[1][1] = 0.25 * (ux1 * ux1 - ux0 * ux0) / uuu[1] / dx;
   dmu[1][2] = 0.25 * (uy1 * uy1 - uy0 * uy0) / uuu[2] / dx;
   dmu[1][3] = 0.25 * (uz1 * uz1 - uz0 * uz0) / uuu[3] / dx;
+  if(vorticityOn) {
+    (*dbeta)[1][0] = 0.5 * (ut1 / T1 - ut0 / T0) / dx;
+    (*dbeta)[1][1] = 0.5 * (ux1 / T1 - ux0 / T0) / dx;
+    (*dbeta)[1][2] = 0.5 * (uy1 / T1 - uy0 / T0) / dx;
+    (*dbeta)[1][3] = 0.5 * (uz1 / T1 - uz0 / T0) / dx;
+    if(e1 <= 0. || e0 <= 0. || T1<=0. || T0<=0.) {
+      (*dbeta)[1][0] = (*dbeta)[1][1] = (*dbeta)[1][2] = (*dbeta)[1][3] = 0.;
+    }
+  }
   if (fabs(0.5 * (ut1 + ut0) / uuu[0]) > UDIFF)
    dmu[1][0] = 0.5 * (ut1 - ut0) / dx;
   if (fabs(uuu[1]) < VMIN || fabs(0.5 * (ux1 + ux0) / uuu[1]) > UDIFF)
@@ -482,8 +518,14 @@ void Hydro::NSquant(int ix, int iy, int iz, double pi[4][4], double &Pi,
  // d_y u^\mu
  f->getCell(ix, iy + 1, iz)
      ->getPrimVarHCenter(eos, tau, e1, p, nb, nq, ns, vx1, vy1, vz1);
+ if (vorticityOn) {
+  eos->eos(e1, nb, nq, ns, T1, mub, muq, mus, p);
+ }
  f->getCell(ix, iy - 1, iz)
      ->getPrimVarHCenter(eos, tau, e0, p, nb, nq, ns, vx0, vy0, vz0);
+ if (vorticityOn) {
+  eos->eos(e0, nb, nq, ns, T0, mub, muq, mus, p);
+ }
  if (e1 > 0. && e0 > 0.) {
   ut0 = 1.0 / sqrt(1.0 - vx0 * vx0 - vy0 * vy0 - vz0 * vz0);
   ux0 = ut0 * vx0;
@@ -497,6 +539,15 @@ void Hydro::NSquant(int ix, int iy, int iz, double pi[4][4], double &Pi,
   dmu[2][1] = 0.25 * (ux1 * ux1 - ux0 * ux0) / uuu[1] / dy;
   dmu[2][2] = 0.25 * (uy1 * uy1 - uy0 * uy0) / uuu[2] / dy;
   dmu[2][3] = 0.25 * (uz1 * uz1 - uz0 * uz0) / uuu[3] / dy;
+  if (vorticityOn) {
+    (*dbeta)[2][0] = 0.5 * (ut1 / T1 - ut0 / T0) / dy;
+    (*dbeta)[2][1] = 0.5 * (ux1 / T1 - ux0 / T0) / dy;
+    (*dbeta)[2][2] = 0.5 * (uy1 / T1 - uy0 / T0) / dy;
+    (*dbeta)[2][3] = 0.5 * (uz1 / T1 - uz0 / T0) / dy;
+    if(e1 <= 0. || e0 <= 0. || T1<=0. || T0<=0.) {
+      (*dbeta)[2][0] = (*dbeta)[2][1] = (*dbeta)[2][2] = (*dbeta)[2][3] = 0.;
+    }
+  }
   if (fabs(0.5 * (ut1 + ut0) / uuu[0]) > UDIFF)
    dmu[2][0] = 0.5 * (ut1 - ut0) / dy;
   if (fabs(uuu[1]) < VMIN || fabs(0.5 * (ux1 + ux0) / uuu[1]) > UDIFF)
@@ -511,8 +562,14 @@ void Hydro::NSquant(int ix, int iy, int iz, double pi[4][4], double &Pi,
  // d_z u^\mu
  f->getCell(ix, iy, iz + 1)
      ->getPrimVarHCenter(eos, tau, e1, p, nb, nq, ns, vx1, vy1, vz1);
+ if (vorticityOn) {
+  eos->eos(e1, nb, nq, ns, T1, mub, muq, mus, p);
+ }
  f->getCell(ix, iy, iz - 1)
      ->getPrimVarHCenter(eos, tau, e0, p, nb, nq, ns, vx0, vy0, vz0);
+ if (vorticityOn) {
+  eos->eos(e0, nb, nq, ns, T0, mub, muq, mus, p);
+ }
  if (e1 > 0. && e0 > 0.) {
   ut0 = 1.0 / sqrt(1.0 - vx0 * vx0 - vy0 * vy0 - vz0 * vz0);
   ux0 = ut0 * vx0;
@@ -526,6 +583,15 @@ void Hydro::NSquant(int ix, int iy, int iz, double pi[4][4], double &Pi,
   dmu[3][1] = 0.25 * (ux1 * ux1 - ux0 * ux0) / uuu[1] / dz / (tau + 0.5 * dt);
   dmu[3][2] = 0.25 * (uy1 * uy1 - uy0 * uy0) / uuu[2] / dz / (tau + 0.5 * dt);
   dmu[3][3] = 0.25 * (uz1 * uz1 - uz0 * uz0) / uuu[3] / dz / (tau + 0.5 * dt);
+  if (vorticityOn) {
+    (*dbeta)[3][0] = 0.5 * (ut1 / T1 - ut0 / T0) / (dz * (tau + 0.5 * dt));
+    (*dbeta)[3][1] = 0.5 * (ux1 / T1 - ux0 / T0) / (dz * (tau + 0.5 * dt));
+    (*dbeta)[3][2] = 0.5 * (uy1 / T1 - uy0 / T0) / (dz * (tau + 0.5 * dt));
+    (*dbeta)[3][3] = 0.5 * (uz1 / T1 - uz0 / T0) / (dz * (tau + 0.5 * dt));
+    if(e1 <= 0. || e0 <= 0. || T1<=0. || T0<=0.){
+      (*dbeta)[3][0] = (*dbeta)[3][1] = (*dbeta)[3][2] = (*dbeta)[3][3] = 0.;
+ }
+  }
   if (fabs(0.5 * (ut1 + ut0) / uuu[0]) > UDIFF)
    dmu[3][0] = 0.5 * (ut1 - ut0) / dz / (tau + 0.5 * dt);
   if (fabs(uuu[1]) < VMIN || fabs(0.5 * (ux1 + ux0) / uuu[1]) > UDIFF)
@@ -540,6 +606,10 @@ void Hydro::NSquant(int ix, int iy, int iz, double pi[4][4], double &Pi,
  // additional terms from Christoffel symbols :)
  dmu[3][0] += uuu[3] / (tau - 0.5 * dt);
  dmu[3][3] += uuu[0] / (tau - 0.5 * dt);
+ if(vorticityOn && T>0.){
+  (*dbeta)[3][0] += uuu[3] / (T * (tau - 0.5 * dt));
+  (*dbeta)[3][3] += uuu[0] / (T * (tau - 0.5 * dt));
+ }
  // calculation of Z[mu][nu][lambda][rho]
  for (int i = 0; i < 4; i++)
   for (int j = 0; j < 4; j++)
@@ -583,7 +653,7 @@ void Hydro::NSquant(int ix, int iy, int iz, double pi[4][4], double &Pi,
 }
 
 void Hydro::setNSvalues() {
- double e, p, nb, nq, ns, vx, vy, vz, piNS[4][4], PiNS, dmu[4][4], du;
+ double e, p, nb, nq, ns, vx, vy, vz, piNS[4][4], PiNS;
  for (int ix = 0; ix < f->getNX(); ix++)
   for (int iy = 0; iy < f->getNY(); iy++)
    for (int iz = 0; iz < f->getNZ(); iz++) {
@@ -613,6 +683,9 @@ void Hydro::setNSvalues() {
 void Hydro::ISformal() {
  double e, p, nb, nq, ns, vx, vy, vz, T, mub, muq, mus;
  double piNS[4][4], sigNS[4][4], PiNS, dmu[4][4], du, pi[4][4], piH[4][4], Pi, PiH;
+ std::unique_ptr<Matrix2D> dbeta = vorticityOn
+    ? std::make_unique<Matrix2D>(Matrix2D(4, std::vector<double>(4)))
+    : nullptr;
  const double gmumu[4] = {1., -1., -1., -1.};
 
  // loop #1 (relaxation+source terms)
@@ -630,6 +703,9 @@ void Hydro::ISformal() {
       }
      c->setPiH0(0.0);
      c->setPi0(0.0);
+     if (vorticityOn) {
+      c->resetDbeta();
+     }
     } else {  // non-empty cell
      // 1) relaxation(pi)+source(pi) terms for half-step
      double gamma = 1.0 / sqrt(1.0 - vx * vx - vy * vy - vz * vz);
@@ -645,7 +721,10 @@ void Hydro::ISformal() {
      flux[0] += -(tau - dt) * c->getPi();
      c->addFlux(flux[0], flux[1], flux[2], flux[3], 0., 0., 0.);
      // now calculating viscous terms in NS limit
-     NSquant(ix, iy, iz, piNS, PiNS, dmu, du);
+     NSquant(ix, iy, iz, piNS, PiNS, dmu, dbeta, du);
+     if (vorticityOn) {
+      c->setDbeta(dbeta);
+     }
      eos->eos(e, nb, nq, ns, T, mub, muq, mus, p);
      double etaS, zetaS;
      const double s = eos->s(e, nb, nq, ns);

--- a/src/hdo.h
+++ b/src/hdo.h
@@ -1,3 +1,4 @@
+#include "cll.h"
 
 class Cell;
 class Fluid;

--- a/src/hdo.h
+++ b/src/hdo.h
@@ -14,9 +14,12 @@ private:
  double dt, tau;  // dt: timestep, tau: current value of the proper time
  double tau_z;    // effective value of the proper time used in 1/tau factors in
                   // the fluxes. Used to increase the accuracy
+ bool vorticityOn = false;
+
 public:
  Hydro(Fluid *_f, EoS *_eos, TransportCoeff *_trcoeff, double _t0, double _dt);
  ~Hydro();
+ void enableVorticity(); // enable vorticity
  void setDtau(double deltaTau);  // change the timestep
  double getDtau() { return dt; }  // return current value of timestep
  void setFluid(Fluid *_f) { f = _f; }
@@ -39,8 +42,8 @@ public:
  // plus \partial_\mu u^\nu matrix (dmu) and
  // expansion scalar \partial_mu u^\mu (du)
  // for a given cell (ix,iy,iz)
- void NSquant(int ix, int iy, int iz, double pi[][4], double &Pi,
-              double dmu[4][4], double &du);
+ void NSquant(int ix, int iy, int iz, double pi[4][4], double &Pi,
+              double dmu[4][4], std::unique_ptr<Matrix2D> &dbeta, double &du);
  // sets the values of shear stress/bulk pressure in NS limit in all hydro grid
  void setNSvalues();
  // advances numerical solution for shear/bulk in a whole grid over one

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -409,12 +409,14 @@ int main(int argc, char **argv) {
   }
   if(nSubSteps>1) {
    h->setDtau(h->getDtau() / nSubSteps);
-   for (int j = 0; j < nSubSteps; j++)
+   for (int j = 0; j < nSubSteps; j++){
     h->performStep();
+   }
    h->setDtau(h->getDtau() * nSubSteps);
    cout << "timestep reduced by " << nSubSteps << endl;
-  } else
+  } else {
    h->performStep();
+  }
   nelements = f->outputSurface(h->getTau(), freezeoutExtend);
   if (!freezeoutOnly)
    f->outputGnuplot(h->getTau());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -67,7 +67,6 @@ void checkGridBorders(double min, double max, std::string _x) {
   }
 }
 
-
 int nx {100}, ny {100}, nz {100}, eosType {1}, etaSparam {0}, zetaSparam {0}, eosTypeHadron {0};
 // only FO hypersurface output: {0,1};  freezeout output extended by e,nb: {0,1}
 bool vtk_cartesian {false}, vtk {false}, freezeoutOnly {false}, freezeoutExtend {false}, vorticityOn {false}; 
@@ -368,11 +367,6 @@ int main(int argc, char **argv) {
  }
  cout << "IC done\n";
 
- // Enable vorticity if key is set in the config file
- if(vorticityOn) {
-  f->enableVorticity();
- }
-
  // For calculating initial anisotropy without running full hydro, uncomment following line
  //f->InitialAnisotropies(tau0) ;
 
@@ -383,6 +377,12 @@ int main(int argc, char **argv) {
 
  // hydro init
  h = new Hydro(f, eos, trcoeff, tau0, dtau);
+
+ // Enable vorticity if key is set in the config file
+ if (vorticityOn) {
+  h -> enableVorticity();
+ }
+
  start = 0;
  time(&start);
  // h->setNSvalues() ; // initialize viscous terms

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -258,12 +258,15 @@ Fluid* expandGrid2x(Hydro* h, EoS* eos, EoS* eosH, TransportCoeff *trcoeff) {
  Fluid* fnew = new Fluid(eos, eosH, trcoeff, f->getNX(), f->getNY(), f->getNZ(),
    2.0*f->getX(0), 2.0*f->getX(f->getNX()-1), 2.0*f->getY(0), 2.0*f->getY(f->getNY()-1),
    f->getZ(0), f->getZ(f->getNZ()-1), 2.0*h->getDtau(), f->geteCrit());
+ if (vorticityOn) fnew->enableVorticity();
  // filling the new fluid
  for(int ix=0; ix<f->getNX(); ix++)
   for(int iy=0; iy<f->getNY(); iy++)
    for(int iz=0; iz<f->getNZ(); iz++) {
     fnew->getCell(ix, iy, iz)->importVars(f->getCell(2*(ix - f->getNX()/2) + f->getNX()/2,
       2*(iy - f->getNY()/2) + f->getNY()/2, iz));
+    // enable vorticity in all cells if it was enabled in the original fluid
+    if (vorticityOn) fnew->getCell(ix, iy, iz)->enableVorticity();
    }
  h->setFluid(fnew);  // now Hydro object operates on the new fluid
  h->setDtau(2.0*h->getDtau());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,7 +70,7 @@ void checkGridBorders(double min, double max, std::string _x) {
 
 int nx {100}, ny {100}, nz {100}, eosType {1}, etaSparam {0}, zetaSparam {0}, eosTypeHadron {0};
 // only FO hypersurface output: {0,1};  freezeout output extended by e,nb: {0,1}
-bool vtk_cartesian {false}, vtk {false}, freezeoutOnly {false}, freezeoutExtend {false}; 
+bool vtk_cartesian {false}, vtk {false}, freezeoutOnly {false}, freezeoutExtend {false}, vorticityOn {false}; 
 double xmin {-5.0}, xmax {5.0}, ymin {-5.0}, ymax {5.0}, etamin {-5.0}, 
   etamax {5.0}, tau0 {1.0}, tauMax {20.0}, tauResize {4.0}, dtau {0.05},
   etaS {0.08}, zetaS {0.0}, eCrit {0.5}, etaSEpsilonMin {5.}, al {0.}, ah {0.}, aRho {0.}, T0 {0.15}, 
@@ -135,6 +135,7 @@ void readParameters(char *parFile) {
         {"etaSScaleMuB", [](const string& value) { etaSScaleMuB = atof(value.c_str()); }},
         {"freezeoutOnly", [](const string& value) { freezeoutOnly = atoi(value.c_str()); }},
         {"freezeoutExtend", [](const string& value) { freezeoutExtend = atoi(value.c_str()); }},
+        {"vorticity", [](const string& value) { vorticityOn = atoi(value.c_str()); }},
         {"smoothingType", [](const string& value) { smoothingType = atoi(value.c_str()); }},
     };
 
@@ -162,6 +163,7 @@ void printParameters() {
  cout << "outputDir = " << outputDir << endl;
  cout << "freezeoutOnly = " << freezeoutOnly << endl;
  cout << "freezeoutExtend = " << freezeoutExtend << endl;
+ cout << "vorticity = " << vorticityOn << endl;
  cout << "eosType = " << eosType << endl;
  cout << "eosTypeHadron = " << eosTypeHadron << endl;
  cout << "nx = " << nx << endl;
@@ -365,6 +367,11 @@ int main(int argc, char **argv) {
    cout << "icModel = " << icModel << " not implemented\n";
  }
  cout << "IC done\n";
+
+ // Enable vorticity if key is set in the config file
+ if(vorticityOn) {
+  f->enableVorticity();
+ }
 
  // For calculating initial anisotropy without running full hydro, uncomment following line
  //f->InitialAnisotropies(tau0) ;


### PR DESCRIPTION
As already announced, this PR combines the functionality of  the branches `stable_ebe` and `polarization_oct2023` such that `stable_ebe` gets the option to create the vorticity file. The PR introduces a new key to the config which produces the vorticity file `beta.dat` optionally.

| New Key     | Values   |
|------------|---------|
| `vorticity`  |  0 or 1    |

The design of the implementation is such that the components of the vorticity tensor are never stored in each cell by value. Rather, it is made sure that the additional RAM usage is minimal. Instead, every cell stores a `unique_ptr` to the vorticity tensor, which is set to a `nullptr` if `vorticity == 0`. Allocation of memory is done only if `vorticity == 1`.

In this way, the additional memory usage is **8 byte per cell**. This means an RAM increase of roughly 0.78 % due to this implementation compared to `stable_ebe`.

To ensure the consistency of the implementation, I have checked that the polarization from this beta.dat file coincides with the polarization of beta.dat coming from the branch `polarization_dbeta_dec2021`, where the result is already known and checked.