### PR TITLE
Remove VTK_cartesian config key and corresponding code

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -220,8 +220,8 @@ void printParameters() {
  cout << "smoothingType = " << smoothingType << endl;
  cout << "impactPar = " << impactPar << endl;
  cout << "s0ScaleFactor = " << s0ScaleFactor << endl;
- cout << "VTK output values = " << vtk_values << endl;
- cout << "VTK cartesian = " << vtk_cartesian << endl;
+ cout << "VTK_output_values = " << vtk_values << endl;
+ cout << "VTK_cartesian = " << vtk_cartesian << endl;
  cout << "======= end parameters =======\n";
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -69,7 +69,7 @@ void checkGridBorders(double min, double max, std::string _x) {
 
 int nx {100}, ny {100}, nz {100}, eosType {1}, etaSparam {0}, zetaSparam {0}, eosTypeHadron {0};
 // only FO hypersurface output: {0,1};  freezeout output extended by e,nb: {0,1}
-bool vtk_cartesian {false}, freezeoutOnly {false}, freezeoutExtend {false}, vorticityOn {false};
+bool freezeoutOnly {false}, freezeoutExtend {false}, vorticityOn {false};
 double xmin {-5.0}, xmax {5.0}, ymin {-5.0}, ymax {5.0}, etamin {-5.0},
   etamax {5.0}, tau0 {1.0}, tauMax {20.0}, tauResize {4.0}, dtau {0.05},
   etaS {0.08}, zetaS {0.0}, eCrit {0.5}, etaSEpsilonMin {5.}, al {0.}, ah {0.}, aRho {0.}, T0 {0.15},
@@ -121,7 +121,6 @@ void readParameters(char *parFile) {
         {"impactPar", [](const string& value) { impactPar = atof(value.c_str()); }},
         {"s0ScaleFactor", [](const string& value) { s0ScaleFactor = atof(value.c_str()); }},
         {"VTK_output_values", [](const string& value) { vtk_values = value; }},
-        {"VTK_cartesian", [](const string& value) { vtk_cartesian= atoi(value.c_str()); }},
         {"etaSparam", [](const string& value) { etaSparam = atoi(value.c_str()); }},
         {"aRho", [](const string& value) { aRho = atof(value.c_str()); }},
         {"ah", [](const string& value) { ah = atof(value.c_str()); }},
@@ -221,7 +220,6 @@ void printParameters() {
  cout << "impactPar = " << impactPar << endl;
  cout << "s0ScaleFactor = " << s0ScaleFactor << endl;
  cout << "VTK_output_values = " << vtk_values << endl;
- cout << "VTK_cartesian = " << vtk_cartesian << endl;
  cout << "======= end parameters =======\n";
 }
 
@@ -395,7 +393,7 @@ int main(int argc, char **argv) {
  bool resized = false; // flag if the grid has been resized
 
  std::string dir=outputDir.c_str();
- VtkOutput vtk_out=VtkOutput(dir,eos,xmin,ymin,etamin,vtk_cartesian);
+ VtkOutput vtk_out=VtkOutput(dir,eos,xmin,ymin,etamin);
 
  int nelements = 0;
  do {

--- a/src/vtk.cpp
+++ b/src/vtk.cpp
@@ -8,26 +8,22 @@
 #include "hdo.h"
 #include "vtk.h"
 
-void VtkOutput::write_header(std::ofstream &file, const Hydro h, const std::string &description) {
-  if (cartesian_) {
-    file << "# vtk DataFile Version 2.0\n"
-      << description << "\n"
-      << "ASCII\n"
-      << "DATASET STRUCTURED_POINTS\n"
-      << "DIMENSIONS " << h.getFluid()->getNX() << " " << h.getFluid()->getNY() << " " << (h.getFluid()->getNZ())*20 << "\n"
-      << "SPACING " << h.getFluid()->getDx() << " " << h.getFluid()->getDy() << " " << h.getTau()*std::sinh(h.getFluid()->getDz()*(h.getFluid()->getNZ()/2))/(20*h.getFluid()->getNZ()/2) << "\n"
-      << "ORIGIN " << xmin_ << " " << ymin_ << " " << etamin_ << "\n"
-      << "POINT_DATA " << h.getFluid()->getNX()*h.getFluid()->getNY()*(h.getFluid()->getNZ())*20 << "\n";
-  } else {
-    file << "# vtk DataFile Version 2.0\n"
-      << description << "\n"
-      << "ASCII\n"
-      << "DATASET STRUCTURED_POINTS\n"
-      << "DIMENSIONS " << h.getFluid()->getNX() << " " << h.getFluid()->getNY() << " " << h.getFluid()->getNZ() << "\n"
-      << "SPACING " << h.getFluid()->getDx() << " " << h.getFluid()->getDy() << " " << h.getFluid()->getDz() << "\n"
-      << "ORIGIN " << xmin_ << " " << ymin_ << " " << etamin_ << "\n"
-      << "POINT_DATA " << h.getFluid()->getNX()*h.getFluid()->getNY()*h.getFluid()->getNZ() << "\n";
-  }
+void VtkOutput::write_header(std::ofstream &file, const Hydro h,
+                             const std::string &description) {
+  num_of_cells_x_direction_ = h.getFluid()->getNX();
+  num_of_cells_y_direction_ = h.getFluid()->getNY();
+  num_of_cells_eta_direction_ = h.getFluid()->getNZ();
+  file << "# vtk DataFile Version 2.0\n"
+    << description << "\n"
+    << "ASCII\n"
+    << "DATASET STRUCTURED_POINTS\n"
+    << "DIMENSIONS " << num_of_cells_x_direction_ << " "
+      << num_of_cells_y_direction_ << " " << num_of_cells_eta_direction_ << "\n"
+    << "SPACING " << h.getFluid()->getDx() << " " << h.getFluid()->getDy()
+                  << " " << h.getFluid()->getDz() << "\n"
+    << "ORIGIN " << xmin_ << " " << ymin_ << " " << etamin_ << "\n"
+    << "POINT_DATA " << num_of_cells_x_direction_ * num_of_cells_y_direction_
+                        * num_of_cells_eta_direction_ << "\n";
 
   return;
 }
@@ -38,96 +34,46 @@ std::string VtkOutput::make_filename(const std::string &descr, int counter) {
   return path_ + std::string("/") + descr + std::string(suffix);
 }
 
-std::vector<double> VtkOutput::smearing_factor_and_poseta(const Hydro h, const int iz, const int z_length) {
-  double poseta = iz;
-  double factor = 1;
-  if (cartesian_) {
-    double total_length = h.getTau()*std::sinh(h.getFluid()->getDz()*(h.getFluid()->getNZ()/2));
-    double pos = 0;
-    int ieta = 0;
-    int end_index_ieta = h.getFluid()->getNZ()/2;
-    if (iz < z_length/2) {
-      pos = -total_length+total_length/(z_length/2)*iz;
-    } else {
-      pos = total_length/(z_length/2)*(iz-z_length/2);
-      ieta = h.getFluid()->getNZ()/2;
-      end_index_ieta = h.getFluid()->getNZ();
-    }
-    while (ieta < end_index_ieta) {
-      if (h.getTau()*std::sinh(h.getFluid()->getDz()*(ieta-h.getFluid()->getNZ()/2)) > pos) {
-        factor = fabs((h.getTau()*std::sinh(h.getFluid()->getDz()*(ieta-h.getFluid()->getNZ()/2))-pos)/pos);
-        poseta = ieta;
-        break;
-      }
-      ieta++;
-    }
-    if (pos == 0) {
-      factor = 1;
-    }
-  }
-  std::vector<double> factor_and_poseta = {factor, poseta};
-  return factor_and_poseta;
-}
-
 void VtkOutput::write_vtk_scalar(std::ofstream &file, const Hydro h,
                                  const std::string &quantity) {
   file << "SCALARS " << quantity << " double 1\n"
        << "LOOKUP_TABLE default\n";
   file << std::setprecision(3);
   file << std::fixed;
-  int z_length = h.getFluid()->getNZ();
-  if (cartesian_) {
-    z_length = 20*z_length;
-  }
 
-  for (int iz = 0; iz < z_length; iz++) {
-    std::vector<double> factor_and_poseta = smearing_factor_and_poseta(h, iz, z_length);
-    double factor = factor_and_poseta.at(0);
-    double poseta = factor_and_poseta.at(1);
-    for (int iy = 0; iy < h.getFluid()->getNY(); iy++) {
-      for (int ix = 0; ix < h.getFluid()->getNX(); ix++) {
+  for (int ieta = 0; ieta < num_of_cells_eta_direction_; ieta++) {
+    for (int iy = 0; iy < num_of_cells_y_direction_; iy++) {
+      for (int ix = 0; ix < num_of_cells_x_direction_; ix++) {
         double e, nb, nq, ns, p, vx, vy, vz;
-        double e2, nb2, nq2, ns2, p2, vx2, vy2, vz2;
-        Cell* cell = h.getFluid()->getCell(ix,iy,poseta);
-        Cell* cell2;
-        if (poseta > 0) {
-          cell2 = h.getFluid()->getCell(ix,iy,poseta-1);
-        } else {
-          cell2 = cell;
-        }
+        Cell* cell = h.getFluid()->getCell(ix,iy,ieta);
         cell->getPrimVar(eos_, h.getTau(), e, p, nb, nq, ns, vx, vy, vz);
-        cell2->getPrimVar(eos_, h.getTau(), e2, p2, nb2, nq2, ns2, vx2, vy2, vz2);
         double q = 0;
         // scalar quantities
         if (quantity == "eps") {
-          q = factor*e+(factor-1)*e2;
+          q = e;
         } else if (quantity == "nb") {
-          q = factor*nb+(factor-1)*nb2;
+          q = nb;
         } else if (quantity == "nq") {
-          q = factor*nq+(factor-1)*nq2;
+          q = nq;
         } else if (quantity == "ns") {
-          q = factor*ns+(factor-1)*ns2;
+          q = ns;
         } else if (quantity == "p") {
-          q = factor*p+(factor-1)*p2;
+          q = p;
         } else if (quantity == "Pi") {
-          double Pi = cell->getPi();
-          double Pi2 = cell2->getPi();
-          q = factor*Pi+(factor-1)*Pi2;
+          q = cell->getPi();
         // scalar quantities that need eos()
         } else if (quantity == "mub" || quantity == "muq" || quantity == "mus"
                    || quantity == "T") {
           double mub, muq, mus, T;
-          double mub2, muq2, mus2, T2;
           eos_->eos(e, nb, nq, ns, T, mub, muq, mus, p);
-          eos_->eos(e2, nb2, nq2, ns2, T2, mub2, muq2, mus2, p2);
           if (quantity == "mub") {
-            q = factor*mub+(factor-1)*mub2;
+            q = mub;
           } else if (quantity == "muq") {
-            q = factor*muq+(factor-1)*muq2;
+            q = muq;
           } else if (quantity == "mus") {
-            q = factor*mus+(factor-1)*mus2;
+            q = mus;
           } else if (quantity == "T") {
-            q = factor*T+(factor-1)*T2;
+            q = T;
           }
         }
         file << q << " ";
@@ -142,31 +88,16 @@ void VtkOutput::write_vtk_vector(std::ofstream &file, const Hydro h,
   file << "VECTORS " << quantity << " double\n";
   file << std::setprecision(3);
   file << std::fixed;
-  int z_length = h.getFluid()->getNZ();
-  if (cartesian_) {
-    z_length = 20*z_length;
-  }
 
-  for (int iz = 0; iz < z_length; iz++) {
-    std::vector<double> factor_and_poseta = smearing_factor_and_poseta(h, iz, z_length);
-    double factor = factor_and_poseta.at(0);
-    double poseta = factor_and_poseta.at(1);
-    for (int iy = 0; iy < h.getFluid()->getNY(); iy++) {
-      for (int ix = 0; ix < h.getFluid()->getNX(); ix++) {
+  for (int ieta = 0; ieta < num_of_cells_eta_direction_; ieta++) {
+    for (int iy = 0; iy < num_of_cells_y_direction_; iy++) {
+      for (int ix = 0; ix < num_of_cells_x_direction_; ix++) {
         double e, p, nb, nq, ns, vx, vy, vz;
-        double e2, p2, nb2, nq2, ns2, vx2, vy2, vz2;
-        Cell* cell = h.getFluid()->getCell(ix,iy,poseta);
-        Cell* cell2;
-        if (poseta > 0) {
-          cell2 = h.getFluid()->getCell(ix,iy,poseta-1);
-        } else {
-          cell2 = cell;
-        }
+        Cell* cell = h.getFluid()->getCell(ix,iy,ieta);
         cell->getPrimVar(eos_, h.getTau(), e, p, nb, nq, ns, vx, vy, vz);
-        cell2->getPrimVar(eos_, h.getTau(), e2, p2, nb2, nq2, ns2, vx2, vy2, vz2);
         std::vector<double> q = {0.,0.,0.};
         if (quantity == "v") {
-          q = {factor*vx+(factor-1)*vx2, factor*vy+(factor-1)*vy2, factor*vz+(factor-1)*vz2};
+          q = {vx, vy, vz};
         }
         file << q.at(0) << " " << q.at(1) << " " << q.at(2) << "\n";
       }
@@ -183,29 +114,14 @@ void VtkOutput::write_vtk_tensor(std::ofstream &file, const Hydro h,
            << "LOOKUP_TABLE default\n";
       file << std::setprecision(3);
       file << std::fixed;
-      int z_length = h.getFluid()->getNZ();
-      if (cartesian_) {
-        z_length = 20*z_length;
-      }
 
-      for (int iz = 0; iz < z_length; iz++) {
-        std::vector<double> factor_and_poseta = smearing_factor_and_poseta(h, iz, z_length);
-        double factor = factor_and_poseta.at(0);
-        double poseta = factor_and_poseta.at(1);
-        for (int iy = 0; iy < h.getFluid()->getNY(); iy++) {
-          for (int ix = 0; ix < h.getFluid()->getNX(); ix++) {
-            Cell* cell = h.getFluid()->getCell(ix,iy,poseta);
-            Cell* cell2;
-            if (poseta > 0) {
-              cell2 = h.getFluid()->getCell(ix,iy,poseta-1);
-            } else {
-              cell2 = cell;
-            }
+      for (int ieta = 0; ieta < num_of_cells_eta_direction_; ieta++) {
+        for (int iy = 0; iy < num_of_cells_y_direction_; iy++) {
+          for (int ix = 0; ix < num_of_cells_x_direction_; ix++) {
+            Cell* cell = h.getFluid()->getCell(ix,iy,ieta);
             double q = 0;
             if (quantity == "pi") {
-              double pi_ij = cell->getpi(i,j);
-              double pi2_ij = cell2->getpi(i,j);
-              q = factor*pi_ij+(factor-1)*pi2_ij;
+              q = cell->getpi(i,j);
             }
             file << q << " ";
           }

--- a/src/vtk.h
+++ b/src/vtk.h
@@ -18,7 +18,8 @@ class VtkOutput {
     std::string path_;
     EoS* eos_;
     double xmin_, ymin_, etamin_;
-    bool cartesian_;
+    int num_of_cells_x_direction_, num_of_cells_y_direction_,
+        num_of_cells_eta_direction_;
     int vtk_output_counter_ = 0;  // Number of vtk output in current event
     /*
      * The following map contains all currently supported VTK quantities.
@@ -52,16 +53,14 @@ class VtkOutput {
      * \param xmin x coordinate of the first cell (center of fluid cell).
      * \param ymin y coordinate of the first cell (center of fluid cell).
      * \param etamin eta coordinate of the first cell (center of fluid cell).
-     * \param cartesian Bool that states if Cartesian output is enabled.
      */
     VtkOutput(std::string path, EoS* eos, double xmin, double ymin,
-              double etamin, bool cartesian=false):
+              double etamin):
                 path_(path),
                 eos_(eos),
                 xmin_(xmin),
                 ymin_(ymin),
-                etamin_(etamin),
-                cartesian_(cartesian)
+                etamin_(etamin)
               {}
 
     void write(const Hydro h, const std::string &quantities);
@@ -74,7 +73,5 @@ class VtkOutput {
     void write_vtk_tensor(std::ofstream &file, const Hydro h,
                           const std::string &quantity);
     bool is_quantity_implemented(const std::string &quantity);
-    std::vector<double> smearing_factor_and_poseta(const Hydro h, const int iz,
-                                                   const int z_length);
     std::string make_filename (const std::string &descr, int counter);
 };

--- a/src/vtk.h
+++ b/src/vtk.h
@@ -21,7 +21,7 @@ class VtkOutput {
     bool cartesian_;
     int vtk_output_counter_ = 0;  // Number of vtk output in current event
     /*
-     * The following vector contains all currently supported VTK quantities.
+     * The following map contains all currently supported VTK quantities.
      * If multiple quantities are desired, the delimiter in the config file has
      * to be a comma without any whitespaces in between, for example:
      * `VTK_output_valus eps,mub,nq,T,v,pi`
@@ -64,17 +64,17 @@ class VtkOutput {
                 cartesian_(cartesian)
               {}
 
-    void write(const Hydro h, std::string &quantity);
+    void write(const Hydro h, const std::string &quantities);
     void write_header(std::ofstream &file, const Hydro h,
                       const std::string &description);
     void write_vtk_scalar(std::ofstream &file, const Hydro h,
-                          std::string &quantity);
+                          const std::string &quantity);
     void write_vtk_vector(std::ofstream &file, const Hydro h,
-                          std::string &quantity);
+                          const std::string &quantity);
     void write_vtk_tensor(std::ofstream &file, const Hydro h,
-                          std::string &quantity);
-    bool is_quantity_implemented(std::string &quantity);
+                          const std::string &quantity);
+    bool is_quantity_implemented(const std::string &quantity);
     std::vector<double> smearing_factor_and_poseta(const Hydro h, const int iz,
-                                    const int z_length);
+                                                   const int z_length);
     std::string make_filename (const std::string &descr, int counter);
 };


### PR DESCRIPTION
As mentioned in issue #33, the plan was to fix the Cartesian VTK output since it contained a few bugs. I realized that the fix is quite complex due to the transformation $t = \tau \cdot \cosh(\eta)$ and the resulting spread of values over multiple Cartesian time files (which is not considered in the code at the moment). Furthermore, this output is probably not used by anyone and since it is not useful because of the bugs, Niklas and I decided to simply remove it. A fortunate side point is that the removal decreased runtime when VTK output is used.

### What I did
- Removed the VTK_cartesian config key and all corresponding code in _src/vtk.h_ and _src/vtk.cpp_.
- Optimized the VTK code in a few locations.

### What I tested
- Created VTK output for `eps`, `mub`, `muq`, `mus`, `nb`, `nq`, `ns`, `p`, `pi`, and `T` with my changes and with the `stable_ebe` branch (with the same config and IC) and compared the outputs. They were identical, so my changes shouldn't have changed anything output-wise.
- Left the old config key `VTK_cartesian 1` in in one run and as expected it was not taken into account.

@NGoetz, could you check the changes and comment or approve?
@yukarpenko, as soon as Niklas approved it would be nice if you could take a look and comment or merge.